### PR TITLE
[Feat] Space CRUD

### DIFF
--- a/http/space.http
+++ b/http/space.http
@@ -1,0 +1,39 @@
+### create space
+POST localhost:8080/api/spaces
+Content-Type: application/json
+Authorization: Bearer {{accessToken}}
+
+{
+  "spaceName": "space Name",
+  "isPublic": "Y",
+  "thumbnail": "VGhpcyBpcyBhIHRlc3QgdGh1bWJuYWls"
+}
+
+> {%
+  client.global.set("spaceId", response.body.id)
+%}
+
+
+### read space
+GET localhost:8080/api/spaces/{{spaceId}}
+Content-Type: application/json
+Authorization: Bearer {{accessToken}}
+
+### update space
+PUT localhost:8080/api/spaces/{{spaceId}}
+Content-Type: application/json
+Authorization: Bearer {{accessToken}}
+
+{
+  "spaceName": "New spaceName",
+  "isPublic": "N",
+  "thumbnail": "VGhpcyBpcyBhIHRlc3QgdGh1bWJuYWls"
+}
+
+### get public space
+GET localhost:8080/api/spaces/public
+Authorization: Bearer {{accessToken}}
+
+### delete space
+DELETE localhost:8080/api/spaces/{{spaceId}}
+Authorization: Bearer {{accessToken}}

--- a/http/user.http
+++ b/http/user.http
@@ -11,9 +11,4 @@ Content-Type: application/json
 ### Security Test
 GET localhost:8080/api/users/test
 Content-Type: application/json
-Authorization: Bearer
-
-### Space Join
-POST localhost:8080/spaces/join/{uuid}
-Content-Type: application/json
-Authorization: Bearer
+Authorization: Bearer {{accessToken}}

--- a/src/main/java/com/echo/echo/domain/space/dto/SpaceResponseDto.java
+++ b/src/main/java/com/echo/echo/domain/space/dto/SpaceResponseDto.java
@@ -1,5 +1,6 @@
 package com.echo.echo.domain.space.dto;
 
+import com.echo.echo.domain.space.entity.Space;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -17,4 +18,17 @@ public class SpaceResponseDto {
     private byte[] thumbnail;
     private String uuid;
     private String message;
+
+    public SpaceResponseDto(Space space, String message) {
+        this.id = space.getId();
+        this.spaceName = space.getSpaceName();
+        this.isPublic = space.getIsPublic();
+        this.thumbnail = space.getThumbnail();
+        this.uuid = space.getUuid();
+        this.message = message;
+    }
+
+    public SpaceResponseDto(Space space) {
+        this(space, null);
+    }
 }

--- a/src/main/java/com/echo/echo/domain/space/entity/SpaceMember.java
+++ b/src/main/java/com/echo/echo/domain/space/entity/SpaceMember.java
@@ -1,6 +1,7 @@
 package com.echo.echo.domain.space.entity;
 
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.relational.core.mapping.Column;
@@ -17,6 +18,7 @@ public class SpaceMember {
     @Column("space_id")
     private Long spaceId;
 
+    @Builder
     public SpaceMember(Long userId, Long spaceId) {
         this.userId = userId;
         this.spaceId = spaceId;


### PR DESCRIPTION
### PR 타입
- [x] 스페이스 CRUD
- [x] 스페이스 입장

### 반영 브랜치
feat/space -> dev

### 변경 사항
Space CRUD 구현

### 테스트 결과
각 컨트롤러 차례대로 포스트맨 테스트 결과 사진 첨부

![스페이스생성](https://github.com/user-attachments/assets/ba21f4ef-61eb-4ff2-a093-d0c867133d6b)
//스페이스 생성

![스페이스 수정](https://github.com/user-attachments/assets/fd9d92b4-9506-4c21-9587-fe759af25c65)
//스페이스 수정
![image](https://github.com/user-attachments/assets/dd416f2e-8b4d-4620-8cba-2afb658b2bd3)
//스페이스 수정 - 예외처리(데이터 없을때)

![공개스페이스조회](https://github.com/user-attachments/assets/f7873ccb-128f-4c41-80f0-9e1179064eda)
//공개 스페이스 조회

![특정스페이스조회](https://github.com/user-attachments/assets/d8a1bf72-965c-4b94-aec8-95bb492e2f7f)
//특정 스페이스 조회

![image](https://github.com/user-attachments/assets/c20e9d03-dc87-4217-914d-556a2dbb1ed0)
//특정 스페이스 조회 - 예외처리(데이터 없을때)

![스페이스 삭제](https://github.com/user-attachments/assets/cee4aa1c-3ad4-41f5-afec-0eac6df85db6)
//스페이스 삭제

![image](https://github.com/user-attachments/assets/57eda730-8581-4307-902f-5bc64bfcec4f)
//스페이스 삭제 -예외처리(데이터 없을때)

![image](https://github.com/user-attachments/assets/6c98a026-116c-4da2-8397-77143f467a48)
//스페이스 입장 성공

![image](https://github.com/user-attachments/assets/b9d092ea-233c-419f-ad4a-247ef1d8f7ed)
//스페이스 입장 실패 -예외처리(uuid 코드가 유효하지 않을 때)

![image](https://github.com/user-attachments/assets/e12e634f-fb61-4d54-8499-48235cfd16ec)
//스페이스 입장 실패 - 예외처리(사용자가 이미 입장한 스페이스 일 때)

