### PR TITLE
[Feat] 로그인 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,14 +27,22 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-r2dbc'
     implementation 'org.springframework.boot:spring-boot-starter-rsocket'
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.security:spring-security-rsocket'
+    implementation 'org.springframework.security:spring-security-messaging'
+    testImplementation 'org.springframework.security:spring-security-test'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'io.projectreactor:reactor-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     runtimeOnly 'org.mariadb:r2dbc-mariadb'
+    compileOnly group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.12.6'
+    runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.12.6'
+    runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.12.6'
 }
 
 tasks.named('test') {
     useJUnitPlatform()
 }
+

--- a/http/auth.http
+++ b/http/auth.http
@@ -1,0 +1,13 @@
+### login
+POST localhost:8080/api/auth/login
+Content-Type: application/json
+
+{
+  "email": "test@test.com",
+  "password": "password"
+}
+
+> {%
+    client.global.set("accessToken", response.body.accessToken)
+    client.global.set("refreshToken", response.body.refreshToken)
+%}

--- a/http/user.http
+++ b/http/user.http
@@ -11,4 +11,9 @@ Content-Type: application/json
 ### Security Test
 GET localhost:8080/api/users/test
 Content-Type: application/json
-Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0QHRlc3QuY29tIiwiYXV0aCI6W10sImV4cCI6MTcyMTgzODczNCwiaWF0IjoxNzIxODM2OTM0fQ.kkzAwk7atQkbTO7ufCzKy0XPOfpsbfYkhKVBMcd26xU0IKniUMyqxDNERreffSqROHNF0dPyyEJ4NEGhKUSwaA
+Authorization: Bearer
+
+### Space Join
+POST localhost:8080/spaces/join/{uuid}
+Content-Type: application/json
+Authorization: Bearer

--- a/src/main/java/com/echo/echo/domain/auth/AuthController.java
+++ b/src/main/java/com/echo/echo/domain/auth/AuthController.java
@@ -1,0 +1,24 @@
+package com.echo.echo.domain.auth;
+
+import com.echo.echo.domain.auth.dto.LoginRequestDto;
+import com.echo.echo.domain.auth.dto.LoginResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Mono;
+
+@RestController
+@RequestMapping("/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final AuthFacade authFacade;
+
+    @PostMapping("login")
+    public Mono<ResponseEntity<LoginResponseDto>> login(@RequestBody LoginRequestDto req) {
+        return authFacade.login(req).map(ResponseEntity::ok);
+    }
+}

--- a/src/main/java/com/echo/echo/domain/auth/AuthFacade.java
+++ b/src/main/java/com/echo/echo/domain/auth/AuthFacade.java
@@ -1,0 +1,22 @@
+package com.echo.echo.domain.auth;
+
+import com.echo.echo.domain.auth.dto.LoginRequestDto;
+import com.echo.echo.domain.auth.dto.LoginResponseDto;
+import com.echo.echo.domain.user.UserFacade;
+import com.echo.echo.domain.user.entity.User;
+import com.echo.echo.security.jwt.Token;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+
+@RequiredArgsConstructor
+@Component
+public class AuthFacade {
+    private final AuthService authService;
+    private final UserFacade userFacade;
+
+    public Mono<LoginResponseDto> login(LoginRequestDto req) {
+        return userFacade.findUserByEmail(req.getEmail())
+                .flatMap(user -> authService.login(req.getPassword(), user));
+    }
+}

--- a/src/main/java/com/echo/echo/domain/auth/AuthService.java
+++ b/src/main/java/com/echo/echo/domain/auth/AuthService.java
@@ -1,0 +1,31 @@
+package com.echo.echo.domain.auth;
+
+import com.echo.echo.domain.auth.dto.LoginResponseDto;
+import com.echo.echo.domain.user.entity.User;
+import com.echo.echo.security.jwt.JwtProvider;
+import com.echo.echo.security.jwt.Token;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
+
+@RequiredArgsConstructor
+@Service
+public class AuthService {
+
+    private final JwtProvider jwtProvider;
+    private final PasswordEncoder passwordEncoder;
+
+    public Mono<LoginResponseDto> login(String inputPassword, User user) {
+        return checkPassword(inputPassword, user.getPassword())
+                .then(Mono.defer(() -> jwtProvider.createToken(user.getId(), user.getEmail())))
+                .map(LoginResponseDto::new);
+    }
+
+    private Mono<Void> checkPassword(String inputPassword, String password) {
+        return Mono.just(passwordEncoder.matches(inputPassword, password))
+                .filter(isMatch -> isMatch)
+                .switchIfEmpty(Mono.error(new IllegalArgumentException("비밀번호가 일치하지 않습니다.")))
+                .then();
+    }
+}

--- a/src/main/java/com/echo/echo/domain/auth/dto/LoginRequestDto.java
+++ b/src/main/java/com/echo/echo/domain/auth/dto/LoginRequestDto.java
@@ -1,0 +1,12 @@
+package com.echo.echo.domain.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class LoginRequestDto {
+    private String email;
+    private String password;
+    private String intro;
+}

--- a/src/main/java/com/echo/echo/domain/auth/dto/LoginResponseDto.java
+++ b/src/main/java/com/echo/echo/domain/auth/dto/LoginResponseDto.java
@@ -1,0 +1,19 @@
+package com.echo.echo.domain.auth.dto;
+
+import com.echo.echo.security.jwt.Token;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+public class LoginResponseDto {
+    @JsonProperty
+    private String accessToken;
+    @JsonProperty
+    private String refreshToken;
+
+    public LoginResponseDto(Token token) {
+        this.accessToken = token.getAccessToken();
+        this.refreshToken = token.getRefreshToken();
+    }
+}

--- a/src/main/java/com/echo/echo/domain/space/SpaceController.java
+++ b/src/main/java/com/echo/echo/domain/space/SpaceController.java
@@ -1,0 +1,48 @@
+package com.echo.echo.domain.space;
+
+import com.echo.echo.domain.space.dto.SpaceRequestDto;
+import com.echo.echo.domain.space.dto.SpaceResponseDto;
+import com.echo.echo.domain.space.service.SpaceService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/spaces")
+public class SpaceController {
+
+    private final SpaceService spaceService;
+
+    @PostMapping
+    public Mono<ResponseEntity<SpaceResponseDto>> createSpace(@RequestBody SpaceRequestDto requestDto) {
+        return spaceService.createSpace(requestDto)
+            .map(ResponseEntity::ok);
+    }
+
+    @PutMapping("/{spaceId}")
+    public Mono<ResponseEntity<SpaceResponseDto>> updateSpace(@PathVariable Long spaceId, @RequestBody SpaceRequestDto requestDto) {
+        return spaceService.updateSpace(spaceId, requestDto)
+            .map(ResponseEntity::ok);
+    }
+
+    @GetMapping("/public")
+    public Flux<SpaceResponseDto> getAllPublicSpaces() {
+        return spaceService.getAllPublicSpaces();
+    }
+
+    @GetMapping("/{spaceId}")
+    public Mono<ResponseEntity<SpaceResponseDto>> getSpaceById(@PathVariable Long spaceId) {
+        return spaceService.getSpaceById(spaceId)
+            .map(ResponseEntity::ok);
+    }
+
+    @DeleteMapping("/{spaceId}")
+    public Mono<ResponseEntity<String>> deleteSpace(@PathVariable Long spaceId) {
+        return spaceService.deleteSpace(spaceId)
+            .then(Mono.just(ResponseEntity.ok("삭제 완료입니다")));
+    }
+
+}

--- a/src/main/java/com/echo/echo/domain/space/SpaceController.java
+++ b/src/main/java/com/echo/echo/domain/space/SpaceController.java
@@ -43,4 +43,11 @@ public class SpaceController {
         return spaceFacade.deleteSpace(spaceId)
             .then(Mono.just(ResponseEntity.ok("삭제 완료입니다")));
     }
+
+    @PostMapping("/join/{uuid}")
+    public Mono<ResponseEntity<SpaceResponseDto>> joinSpace(@PathVariable String uuid, @RequestHeader("Authorization") String authorization) {
+        return spaceFacade.joinSpace(uuid, authorization)
+            .map(ResponseEntity::ok)
+            .switchIfEmpty(Mono.just(ResponseEntity.badRequest().body(null))); //메세지는 추후에
+    }
 }

--- a/src/main/java/com/echo/echo/domain/space/SpaceController.java
+++ b/src/main/java/com/echo/echo/domain/space/SpaceController.java
@@ -2,8 +2,10 @@ package com.echo.echo.domain.space;
 
 import com.echo.echo.domain.space.dto.SpaceRequestDto;
 import com.echo.echo.domain.space.dto.SpaceResponseDto;
+import com.echo.echo.security.principal.UserPrincipal;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -45,9 +47,11 @@ public class SpaceController {
     }
 
     @PostMapping("/join/{uuid}")
-    public Mono<ResponseEntity<SpaceResponseDto>> joinSpace(@PathVariable String uuid, @RequestHeader("Authorization") String authorization) {
-        return spaceFacade.joinSpace(uuid, authorization)
+    public Mono<ResponseEntity<SpaceResponseDto>> joinSpace(@PathVariable String uuid, @AuthenticationPrincipal UserPrincipal userPrincipal) {
+        return spaceFacade.joinSpace(uuid, userPrincipal.getUser().getId())
             .map(ResponseEntity::ok)
-            .switchIfEmpty(Mono.just(ResponseEntity.badRequest().body(null))); //메세지는 추후에
+            .switchIfEmpty(Mono.just(ResponseEntity.badRequest()
+                .body(SpaceResponseDto.builder().message("입장 실패: 코드가 유효하지 않습니다.").build())));
     }
+
 }

--- a/src/main/java/com/echo/echo/domain/space/SpaceController.java
+++ b/src/main/java/com/echo/echo/domain/space/SpaceController.java
@@ -40,6 +40,7 @@ public class SpaceController {
 
     @DeleteMapping("/{spaceId}")
     public Mono<ResponseEntity<String>> deleteSpace(@PathVariable Long spaceId) {
-        return spaceFacade.deleteSpace(spaceId);
+        return spaceFacade.deleteSpace(spaceId)
+            .then(Mono.just(ResponseEntity.ok("삭제 완료입니다")));
     }
 }

--- a/src/main/java/com/echo/echo/domain/space/SpaceController.java
+++ b/src/main/java/com/echo/echo/domain/space/SpaceController.java
@@ -2,7 +2,6 @@ package com.echo.echo.domain.space;
 
 import com.echo.echo.domain.space.dto.SpaceRequestDto;
 import com.echo.echo.domain.space.dto.SpaceResponseDto;
-import com.echo.echo.domain.space.service.SpaceService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -14,35 +13,33 @@ import reactor.core.publisher.Mono;
 @RequestMapping("/spaces")
 public class SpaceController {
 
-    private final SpaceService spaceService;
+    private final SpaceFacade spaceFacade;
 
     @PostMapping
     public Mono<ResponseEntity<SpaceResponseDto>> createSpace(@RequestBody SpaceRequestDto requestDto) {
-        return spaceService.createSpace(requestDto)
+        return spaceFacade.createSpace(requestDto)
             .map(ResponseEntity::ok);
     }
 
     @PutMapping("/{spaceId}")
     public Mono<ResponseEntity<SpaceResponseDto>> updateSpace(@PathVariable Long spaceId, @RequestBody SpaceRequestDto requestDto) {
-        return spaceService.updateSpace(spaceId, requestDto)
+        return spaceFacade.updateSpace(spaceId, requestDto)
             .map(ResponseEntity::ok);
     }
 
     @GetMapping("/public")
     public Flux<SpaceResponseDto> getAllPublicSpaces() {
-        return spaceService.getAllPublicSpaces();
+        return spaceFacade.getAllPublicSpaces();
     }
 
     @GetMapping("/{spaceId}")
     public Mono<ResponseEntity<SpaceResponseDto>> getSpaceById(@PathVariable Long spaceId) {
-        return spaceService.getSpaceById(spaceId)
+        return spaceFacade.getSpaceById(spaceId)
             .map(ResponseEntity::ok);
     }
 
     @DeleteMapping("/{spaceId}")
     public Mono<ResponseEntity<String>> deleteSpace(@PathVariable Long spaceId) {
-        return spaceService.deleteSpace(spaceId)
-            .then(Mono.just(ResponseEntity.ok("삭제 완료입니다")));
+        return spaceFacade.deleteSpace(spaceId);
     }
-
 }

--- a/src/main/java/com/echo/echo/domain/space/SpaceFacade.java
+++ b/src/main/java/com/echo/echo/domain/space/SpaceFacade.java
@@ -2,9 +2,7 @@ package com.echo.echo.domain.space;
 
 import com.echo.echo.domain.space.dto.SpaceRequestDto;
 import com.echo.echo.domain.space.dto.SpaceResponseDto;
-import com.echo.echo.domain.space.service.SpaceService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -31,8 +29,7 @@ public class SpaceFacade {
         return spaceService.getSpaceById(spaceId);
     }
 
-    public Mono<ResponseEntity<String>> deleteSpace(Long spaceId) {
-        return spaceService.deleteSpace(spaceId)
-                .then(Mono.just(ResponseEntity.ok("삭제 완료입니다")));
+    public Mono<Void> deleteSpace(Long spaceId) {
+        return spaceService.deleteSpace(spaceId);
     }
 }

--- a/src/main/java/com/echo/echo/domain/space/SpaceFacade.java
+++ b/src/main/java/com/echo/echo/domain/space/SpaceFacade.java
@@ -33,7 +33,7 @@ public class SpaceFacade {
         return spaceService.deleteSpace(spaceId);
     }
 
-    public Mono<SpaceResponseDto> joinSpace(String uuid, String authorization) {
-        return spaceService.joinSpace(uuid, authorization);
+    public Mono<SpaceResponseDto> joinSpace(String uuid, Long userId) {
+        return spaceService.joinSpace(uuid, userId);
     }
 }

--- a/src/main/java/com/echo/echo/domain/space/SpaceFacade.java
+++ b/src/main/java/com/echo/echo/domain/space/SpaceFacade.java
@@ -32,4 +32,8 @@ public class SpaceFacade {
     public Mono<Void> deleteSpace(Long spaceId) {
         return spaceService.deleteSpace(spaceId);
     }
+
+    public Mono<SpaceResponseDto> joinSpace(String uuid, String authorization) {
+        return spaceService.joinSpace(uuid, authorization);
+    }
 }

--- a/src/main/java/com/echo/echo/domain/space/SpaceFacade.java
+++ b/src/main/java/com/echo/echo/domain/space/SpaceFacade.java
@@ -1,0 +1,38 @@
+package com.echo.echo.domain.space;
+
+import com.echo.echo.domain.space.dto.SpaceRequestDto;
+import com.echo.echo.domain.space.dto.SpaceResponseDto;
+import com.echo.echo.domain.space.service.SpaceService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+@RequiredArgsConstructor
+@Component
+public class SpaceFacade {
+
+    private final SpaceService spaceService;
+
+    public Mono<SpaceResponseDto> createSpace(SpaceRequestDto requestDto) {
+        return spaceService.createSpace(requestDto);
+    }
+
+    public Mono<SpaceResponseDto> updateSpace(Long spaceId, SpaceRequestDto requestDto) {
+        return spaceService.updateSpace(spaceId, requestDto);
+    }
+
+    public Flux<SpaceResponseDto> getAllPublicSpaces() {
+        return spaceService.getAllPublicSpaces();
+    }
+
+    public Mono<SpaceResponseDto> getSpaceById(Long spaceId) {
+        return spaceService.getSpaceById(spaceId);
+    }
+
+    public Mono<ResponseEntity<String>> deleteSpace(Long spaceId) {
+        return spaceService.deleteSpace(spaceId)
+                .then(Mono.just(ResponseEntity.ok("삭제 완료입니다")));
+    }
+}

--- a/src/main/java/com/echo/echo/domain/space/SpaceService.java
+++ b/src/main/java/com/echo/echo/domain/space/SpaceService.java
@@ -1,4 +1,4 @@
-package com.echo.echo.domain.space.service;
+package com.echo.echo.domain.space;
 
 import com.echo.echo.domain.space.dto.SpaceRequestDto;
 import com.echo.echo.domain.space.dto.SpaceResponseDto;

--- a/src/main/java/com/echo/echo/domain/space/SpaceService.java
+++ b/src/main/java/com/echo/echo/domain/space/SpaceService.java
@@ -1,0 +1,65 @@
+package com.echo.echo.domain.space.service;
+
+import com.echo.echo.domain.space.dto.SpaceRequestDto;
+import com.echo.echo.domain.space.dto.SpaceResponseDto;
+import com.echo.echo.domain.space.entity.Space;
+import com.echo.echo.domain.space.repository.SpaceRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+@RequiredArgsConstructor
+@Service
+public class SpaceService {
+
+    private final SpaceRepository spaceRepository;
+
+    public Mono<SpaceResponseDto> createSpace(SpaceRequestDto requestDto) {
+        Space space = Space.builder()
+            .spaceName(requestDto.getSpaceName())
+            .isPublic(requestDto.getIsPublic())
+            .thumbnail(requestDto.getThumbnail())
+            .build();
+        return spaceRepository.save(space)
+            .map(this::toResponseDto);
+    }
+
+    public Mono<SpaceResponseDto> updateSpace(Long spaceId, SpaceRequestDto requestDto) {
+        return spaceRepository.findById(spaceId)
+            .flatMap(existingSpace -> {
+                Space updatedSpace = existingSpace.update(
+                    requestDto.getSpaceName(),
+                    requestDto.getIsPublic(),
+                    requestDto.getThumbnail()
+                );
+                return spaceRepository.save(updatedSpace)
+                    .map(this::toResponseDto);
+            });
+    }
+
+    public Flux<SpaceResponseDto> getAllPublicSpaces() {
+        return spaceRepository.findAll()
+            .filter(space -> "Y".equals(space.getIsPublic()))
+            .map(this::toResponseDto);
+    }
+
+    public Mono<SpaceResponseDto> getSpaceById(Long spaceId) {
+        return spaceRepository.findById(spaceId)
+            .map(this::toResponseDto);
+    }
+
+    public Mono<Void> deleteSpace(Long spaceId) {
+        return spaceRepository.deleteById(spaceId);
+    }
+
+    private SpaceResponseDto toResponseDto(Space space) {
+        return SpaceResponseDto.builder()
+            .id(space.getId())
+            .spaceName(space.getSpaceName())
+            .isPublic(space.getIsPublic())
+            .thumbnail(space.getThumbnail())
+            .uuid(space.getUuid())
+            .build();
+    }
+}

--- a/src/main/java/com/echo/echo/domain/space/dto/SpaceRequestDto.java
+++ b/src/main/java/com/echo/echo/domain/space/dto/SpaceRequestDto.java
@@ -1,0 +1,16 @@
+package com.echo.echo.domain.space.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class SpaceRequestDto {
+
+    private String spaceName;
+    private String isPublic;
+    private byte[] thumbnail;
+}

--- a/src/main/java/com/echo/echo/domain/space/dto/SpaceResponseDto.java
+++ b/src/main/java/com/echo/echo/domain/space/dto/SpaceResponseDto.java
@@ -1,0 +1,19 @@
+package com.echo.echo.domain.space.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class SpaceResponseDto {
+    private Long id;
+    private String spaceName;
+    private String isPublic;
+    private byte[] thumbnail;
+    private String uuid;
+}

--- a/src/main/java/com/echo/echo/domain/space/dto/SpaceResponseDto.java
+++ b/src/main/java/com/echo/echo/domain/space/dto/SpaceResponseDto.java
@@ -16,4 +16,5 @@ public class SpaceResponseDto {
     private String isPublic;
     private byte[] thumbnail;
     private String uuid;
+    private String message;
 }

--- a/src/main/java/com/echo/echo/domain/space/entity/Space.java
+++ b/src/main/java/com/echo/echo/domain/space/entity/Space.java
@@ -10,7 +10,6 @@ import org.springframework.data.relational.core.mapping.Table;
 
 import java.util.UUID;
 
-
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @Table(name = "space")
@@ -20,14 +19,25 @@ public class Space extends TimeStamp {
     private Long id;
     private String spaceName;
     private String isPublic;
-    private byte[] thumnail;
+    private byte[] thumbnail;
     private String uuid;
 
     @Builder
-    public Space(String spaceName, String isPublic, byte[] thumnail) {
+    public Space(Long id, String spaceName, String isPublic, byte[] thumbnail, String uuid) {
+        this.id = id;
         this.spaceName = spaceName;
         this.isPublic = isPublic;
-        this.thumnail = thumnail;
-        this.uuid = UUID.randomUUID().toString();
+        this.thumbnail = thumbnail;
+        this.uuid = uuid != null ? uuid : UUID.randomUUID().toString();
+    }
+
+    public Space update(String spaceName, String isPublic, byte[] thumbnail) {
+        return Space.builder()
+            .id(this.id)
+            .spaceName(spaceName)
+            .isPublic(isPublic)
+            .thumbnail(thumbnail)
+            .uuid(this.uuid)
+            .build();
     }
 }

--- a/src/main/java/com/echo/echo/domain/space/entity/SpaceMember.java
+++ b/src/main/java/com/echo/echo/domain/space/entity/SpaceMember.java
@@ -3,15 +3,18 @@ package com.echo.echo.domain.space.entity;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.data.annotation.Id;
+import org.springframework.data.relational.core.mapping.Column;
 import org.springframework.data.relational.core.mapping.Table;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @Table(name = "space_member")
 public class SpaceMember {
-    @Id
+
+    @Column("user_id")
     private Long userId;
+
+    @Column("space_id")
     private Long spaceId;
 
     public SpaceMember(Long userId, Long spaceId) {

--- a/src/main/java/com/echo/echo/domain/space/entity/SpaceMember.java
+++ b/src/main/java/com/echo/echo/domain/space/entity/SpaceMember.java
@@ -1,0 +1,21 @@
+package com.echo.echo.domain.space.entity;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.relational.core.mapping.Table;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Table(name = "space_member")
+public class SpaceMember {
+    @Id
+    private Long userId;
+    private Long spaceId;
+
+    public SpaceMember(Long userId, Long spaceId) {
+        this.userId = userId;
+        this.spaceId = spaceId;
+    }
+}

--- a/src/main/java/com/echo/echo/domain/space/repository/SpaceMemberRepository.java
+++ b/src/main/java/com/echo/echo/domain/space/repository/SpaceMemberRepository.java
@@ -1,0 +1,9 @@
+package com.echo.echo.domain.space.repository;
+
+import com.echo.echo.domain.space.entity.SpaceMember;
+import org.springframework.data.repository.reactive.ReactiveCrudRepository;
+import reactor.core.publisher.Mono;
+
+public interface SpaceMemberRepository extends ReactiveCrudRepository<SpaceMember, Long> {
+    Mono<SpaceMember> findByUserIdAndSpaceId(Long userId, Long spaceId);
+}

--- a/src/main/java/com/echo/echo/domain/space/repository/SpaceRepository.java
+++ b/src/main/java/com/echo/echo/domain/space/repository/SpaceRepository.java
@@ -2,7 +2,8 @@ package com.echo.echo.domain.space.repository;
 
 import com.echo.echo.domain.space.entity.Space;
 import org.springframework.data.repository.reactive.ReactiveCrudRepository;
+import reactor.core.publisher.Mono;
 
 public interface SpaceRepository extends ReactiveCrudRepository<Space, Long> {
-
+    Mono<Space> findByUuid(String uuid);
 }

--- a/src/main/java/com/echo/echo/security/config/SecurityConfig.java
+++ b/src/main/java/com/echo/echo/security/config/SecurityConfig.java
@@ -1,6 +1,6 @@
 package com.echo.echo.security.config;
 
-import com.echo.echo.security.jwt.JwtService;
+import com.echo.echo.security.jwt.JwtProvider;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;
@@ -17,7 +17,6 @@ import org.springframework.security.web.server.SecurityWebFilterChain;
 import org.springframework.security.web.server.authentication.AuthenticationWebFilter;
 import org.springframework.security.web.server.authentication.ServerAuthenticationConverter;
 import org.springframework.security.web.server.context.NoOpServerSecurityContextRepository;
-import org.springframework.util.StringUtils;
 import reactor.core.publisher.Mono;
 
 @RequiredArgsConstructor
@@ -26,7 +25,7 @@ import reactor.core.publisher.Mono;
 @Slf4j
 public class SecurityConfig {
 
-    private final JwtService jwtService;
+    private final JwtProvider jwtProvider;
 
     @Bean
     public PasswordEncoder passwordEncoder() {
@@ -54,7 +53,7 @@ public class SecurityConfig {
 
                 .authorizeExchange(authorizeExchangeSpec -> authorizeExchangeSpec
                         .pathMatchers(HttpMethod.GET,"/auth").permitAll()
-                        .pathMatchers(HttpMethod.POST, "/users/signup").permitAll()
+                        .pathMatchers(HttpMethod.POST, "/users/signup", "/auth/**").permitAll()
                         .anyExchange().authenticated()
                 )
                 .addFilterAt(authenticationWebFilter(), SecurityWebFiltersOrder.AUTHENTICATION)
@@ -71,8 +70,8 @@ public class SecurityConfig {
     }
 
     private ServerAuthenticationConverter serverAuthenticationConverter() {
-        return exchange -> jwtService.resolveToken(exchange.getRequest())
-                .filter(jwtService::isValidToken)
-                .flatMap(token -> Mono.justOrEmpty(jwtService.getAuthentication(token)));
+        return exchange -> jwtProvider.resolveToken(exchange.getRequest())
+                .filter(jwtProvider::isValidToken)
+                .flatMap(token -> Mono.justOrEmpty(jwtProvider.getAuthentication(token)));
     }
 }

--- a/src/main/java/com/echo/echo/security/jwt/Token.java
+++ b/src/main/java/com/echo/echo/security/jwt/Token.java
@@ -1,0 +1,16 @@
+package com.echo.echo.security.jwt;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class Token {
+    private final String accessToken;
+    private final String refreshToken;
+
+    @Builder
+    public Token(String accessToken, String refreshToken) {
+        this.accessToken = accessToken;
+        this.refreshToken = refreshToken;
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,3 +5,7 @@ spring.r2dbc.username=${MARIADB_USER}
 spring.r2dbc.password=${MARIADB_PASSWORD}
 
 logging.level.org.springframework.r2dbc=debug
+
+jwt.secret=${JWT_SECRET}
+jwt.time.access=${JWT_ACCESS_TIME}
+jwt.time.refresh=${JWT_REFRESH_TIME}

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -10,7 +10,7 @@ create table if not exists space (
     id bigint auto_increment primary key,
     space_name varchar(20) not null,
     is_public varchar(1) default 'n' not null,
-    thumnail blob,
+    thumbnail blob,
     uuid varchar(36) not null,
     created_at timestamp not null,
     modified_at timestamp not null
@@ -41,3 +41,5 @@ create table if not exists text (
     foreign key(user_id) references user(id),
     foreign key(channel_id) references channel(id)
 );
+
+

--- a/src/test/java/com/echo/echo/security/jwt/JwtProviderTest.java
+++ b/src/test/java/com/echo/echo/security/jwt/JwtProviderTest.java
@@ -4,19 +4,17 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
-import static org.junit.jupiter.api.Assertions.*;
-
 @SpringBootTest
-class JwtServiceTest {
+class JwtProviderTest {
 
     @Autowired
-    JwtService jwtService;
+    JwtProvider jwtProvider;
 
     @Test
-    void createToken() {
+    void createAccessToken() {
         Long id = 1L;
         String email = "test@test.com";
-        String token = jwtService.createToken(id, email);
+        String token = jwtProvider.createAccessToken(id, email);
         System.out.println(token);
     }
 }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가

### 반영 브랜치
ex) feat/login -> dev
feat/auth

### 변경 사항
ex) 로그인 시, 구글 소셜 로그인 기능을 추가했습니다.
로그인 시 accessToken과 refreshToken을 발급하도록 했습니다.

### 테스트 결과
ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다.

정상적인 사용자 로그인
![image](https://github.com/user-attachments/assets/5f907f24-c4a2-4825-b7c3-92d93def9b96)

아이디가 없는 경우
![image](https://github.com/user-attachments/assets/7c894456-85d4-42b5-8482-12f0e433750b)

비밀번호가 틀린 경우
![image](https://github.com/user-attachments/assets/ccbf4f18-79f7-4122-b7fc-56c727410e08)

### 특이사항
- 현재 서버 에러 시 항상 500에러로 응답이 되기에 에러 처리 완료한 화면을 캡처했습니다.
- Exception의 경우 임의로 처리했기에 공통 처리 Exception 구현이 완료되면 수정 예정입니다.
