### PR TITLE
[Feat] 유저 활성화 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.security:spring-security-rsocket'
     implementation 'org.springframework.security:spring-security-messaging'
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
     testImplementation 'org.springframework.security:spring-security-test'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/http/user.http
+++ b/http/user.http
@@ -3,9 +3,17 @@ POST localhost:8080/api/users/signup
 Content-Type: application/json
 
 {
-  "email": "test@test.com",
+  "email": "apfhd0257@naver.com",
   "password": "password",
   "intro": "intro"
+}
+
+### user activate
+POST localhost:8080/api/users/activate/111800
+Content-Type: application/json
+
+{
+  "email": "apfhd0257@naver.com"
 }
 
 ### Security Test

--- a/src/main/java/com/echo/echo/config/MailConfig.java
+++ b/src/main/java/com/echo/echo/config/MailConfig.java
@@ -1,0 +1,43 @@
+package com.echo.echo.config;
+
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+import java.util.Properties;
+
+@Configuration
+public class MailConfig {
+    @Value("${spring.mail.username}")
+    private String username;
+
+    @Value("${spring.mail.password}")
+    private String password;
+
+    @Bean
+    public JavaMailSender javaMailSender() {
+        JavaMailSenderImpl javaMailSender = new JavaMailSenderImpl();
+        javaMailSender.setHost("smtp.gmail.com");
+        javaMailSender.setPort(587);
+        javaMailSender.setUsername(username);
+        javaMailSender.setPassword(password);
+        javaMailSender.setJavaMailProperties(getMailProperties());
+        return javaMailSender;
+    }
+
+    private Properties getMailProperties() {
+        Properties properties = new Properties();
+        properties.setProperty("mail.transport.protocol", "smtp"); // 프로토콜 설정
+        properties.setProperty("mail.smtp.auth", String.valueOf(true)); // smtp 인증
+        properties.setProperty("mail.smtp.starttls.enable", String.valueOf(true)); // smtp strattles 사용
+        properties.setProperty("mail.debug", String.valueOf(true)); // 디버그 사용
+        return properties;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+}

--- a/src/main/java/com/echo/echo/domain/auth/AuthController.java
+++ b/src/main/java/com/echo/echo/domain/auth/AuthController.java
@@ -2,12 +2,10 @@ package com.echo.echo.domain.auth;
 
 import com.echo.echo.domain.auth.dto.LoginRequestDto;
 import com.echo.echo.domain.auth.dto.LoginResponseDto;
+import com.echo.echo.domain.auth.dto.VerificationRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import reactor.core.publisher.Mono;
 
 @RestController

--- a/src/main/java/com/echo/echo/domain/auth/AuthFacade.java
+++ b/src/main/java/com/echo/echo/domain/auth/AuthFacade.java
@@ -2,6 +2,7 @@ package com.echo.echo.domain.auth;
 
 import com.echo.echo.domain.auth.dto.LoginRequestDto;
 import com.echo.echo.domain.auth.dto.LoginResponseDto;
+import com.echo.echo.domain.auth.dto.VerificationRequest;
 import com.echo.echo.domain.user.UserFacade;
 import com.echo.echo.domain.user.entity.User;
 import com.echo.echo.security.jwt.Token;

--- a/src/main/java/com/echo/echo/domain/auth/AuthService.java
+++ b/src/main/java/com/echo/echo/domain/auth/AuthService.java
@@ -9,6 +9,8 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Mono;
 
+import java.util.Random;
+
 @RequiredArgsConstructor
 @Service
 public class AuthService {

--- a/src/main/java/com/echo/echo/domain/auth/dto/VerificationRequest.java
+++ b/src/main/java/com/echo/echo/domain/auth/dto/VerificationRequest.java
@@ -1,0 +1,8 @@
+package com.echo.echo.domain.auth.dto;
+
+import lombok.Getter;
+
+@Getter
+public class VerificationRequest {
+    private String email;
+}

--- a/src/main/java/com/echo/echo/domain/mail/Mail.java
+++ b/src/main/java/com/echo/echo/domain/mail/Mail.java
@@ -1,0 +1,27 @@
+package com.echo.echo.domain.mail;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class Mail {
+    private final String to;
+    private final String subject;
+    private final String body;
+
+    @Builder
+    public Mail(String to, String subject, String body) {
+        this.to = to;
+        this.subject = subject;
+        this.body = body;
+    }
+
+    public static String createSignupMailBody(String verificationCode) {
+        return """
+                <!DOCTYPE html>
+                <body>
+                    인증번호는 ${code}입니다.
+                </body>
+                </html>""".replace("${code}", verificationCode);
+    }
+}

--- a/src/main/java/com/echo/echo/domain/mail/MailService.java
+++ b/src/main/java/com/echo/echo/domain/mail/MailService.java
@@ -1,0 +1,35 @@
+package com.echo.echo.domain.mail;
+
+import com.echo.echo.config.MailConfig;
+import jakarta.mail.internet.InternetAddress;
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
+
+@RequiredArgsConstructor
+@Service
+public class MailService {
+    private final MailConfig mailConfig;
+    private final JavaMailSender javaMailSender;
+
+    public Mono<Boolean> sendMail(Mail mail) {
+        return Mono.fromCallable(() -> {
+            MimeMessage message = javaMailSender.createMimeMessage();
+            MimeMessageHelper mimeMessageHelper = new MimeMessageHelper(message, true, "UTF-8");
+
+            mimeMessageHelper.addTo(mail.getTo());
+            mimeMessageHelper.setFrom(new InternetAddress(mailConfig.getUsername(), "Echo"));
+            mimeMessageHelper.setSubject("Echo " + mail.getSubject());
+
+            mimeMessageHelper.setText(mail.getBody(), true);
+//            이미지 삽입
+//            mimeMessageHelper.addInline("logo", new ClassPathResource("static/images/logo_mail.png"));
+
+            javaMailSender.send(message);
+            return true;
+        }).doOnError(error -> System.out.println("error = " + error)).then(Mono.just(false));
+    }
+}

--- a/src/main/java/com/echo/echo/domain/user/UserController.java
+++ b/src/main/java/com/echo/echo/domain/user/UserController.java
@@ -1,5 +1,7 @@
 package com.echo.echo.domain.user;
 
+import com.echo.echo.domain.auth.dto.LoginResponseDto;
+import com.echo.echo.domain.auth.dto.VerificationRequest;
 import com.echo.echo.domain.user.dto.UserRequestDto;
 import com.echo.echo.domain.user.dto.UserResponseDto;
 import com.echo.echo.security.principal.UserPrincipal;
@@ -19,6 +21,12 @@ public class UserController {
     @PostMapping("/signup")
     public Mono<ResponseEntity<UserResponseDto>> signup(@RequestBody UserRequestDto req) {
         return userFacade.signup(req).map(ResponseEntity::ok);
+    }
+
+    @PostMapping("activate/{code}")
+    public Mono<ResponseEntity<String>> activate(@PathVariable("code") int code, @RequestBody VerificationRequest req) {
+        return userFacade.verifyCode(code, req)
+                .then(Mono.just(ResponseEntity.ok("계정 활성화가 완료되었습니다.")));
     }
 
     @GetMapping("/test")

--- a/src/main/java/com/echo/echo/domain/user/UserFacade.java
+++ b/src/main/java/com/echo/echo/domain/user/UserFacade.java
@@ -1,20 +1,43 @@
 package com.echo.echo.domain.user;
 
+import com.echo.echo.domain.auth.AuthFacade;
+import com.echo.echo.domain.auth.AuthService;
+import com.echo.echo.domain.auth.dto.VerificationRequest;
+import com.echo.echo.domain.mail.Mail;
+import com.echo.echo.domain.mail.MailService;
 import com.echo.echo.domain.user.dto.UserRequestDto;
 import com.echo.echo.domain.user.dto.UserResponseDto;
 import com.echo.echo.domain.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+
+import java.util.Random;
 
 @RequiredArgsConstructor
 @Component
 public class UserFacade {
     private final UserService userService;
+    private final MailService mailService;
 
-    public Mono<UserResponseDto> signup(UserRequestDto userRequestDto) {
-        return userService.signup(userRequestDto)
+    public Mono<UserResponseDto> signup(UserRequestDto req) {
+        return userService.signup(req)
+                .publishOn(Schedulers.boundedElastic())
+                .doOnNext(user -> {
+                    Mail mail = Mail.builder()
+                            .to(req.getEmail())
+                            .subject("계정 확인 메일")
+                            .body(Mail.createSignupMailBody(String.valueOf(user.getVerificationCode())))
+                            .build();
+                    mailService.sendMail(mail).subscribe(data -> System.out.println("메일 전송 완료"));
+                })
                 .map(UserResponseDto::new);
+    }
+
+    public Mono<Void> verifyCode(int code, VerificationRequest req) {
+        return userService.checkVerificationCodeAndActivateUser(code, req.getEmail());
     }
 
     public Mono<User> findUserByEmail(String email) {

--- a/src/main/java/com/echo/echo/domain/user/UserService.java
+++ b/src/main/java/com/echo/echo/domain/user/UserService.java
@@ -5,7 +5,6 @@ import com.echo.echo.domain.user.entity.User;
 import com.echo.echo.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.stereotype.Component;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
@@ -38,9 +37,21 @@ public class UserService {
         return null;
     }
 
+    protected Mono<User> activateUserStatus(User user) {
+        user.activateStatus();
+        return userRepository.save(user);
+    }
+
+    public Mono<Void> checkVerificationCodeAndActivateUser(int code, String email) {
+        return findByEmail(email)
+                .filter(user -> user.checkVerificationCode(code))
+                .switchIfEmpty(Mono.error(new IllegalArgumentException("인증번호가 올바르지 않습니다.")))
+                .flatMap(this::activateUserStatus).then();
+    }
+
     protected Mono<User> findByEmail(String email) {
         return userRepository.findByEmail(email)
-                .switchIfEmpty(Mono.error(new IllegalArgumentException("해당하는 이메일이 존재하지 않습니다.")));
+                .switchIfEmpty(Mono.error(new IllegalArgumentException("해당하는 이메일을 찾을 수 없습니다.")));
     }
 
     protected Mono<Boolean> existsByEmail(String email) {

--- a/src/main/java/com/echo/echo/domain/user/entity/User.java
+++ b/src/main/java/com/echo/echo/domain/user/entity/User.java
@@ -1,14 +1,12 @@
 package com.echo.echo.domain.user.entity;
 
-import com.echo.echo.domain.text.entity.Text;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.Id;
-import org.springframework.data.annotation.Transient;
 
-import java.util.List;
+import java.util.Random;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
@@ -19,6 +17,7 @@ public class User {
     private String password;
     private String intro;
     private int status;
+    private int verificationCode;
 
     // 상태: 인증 전, 인증 완료, 탈퇴
     public enum Status {
@@ -26,11 +25,23 @@ public class User {
     }
 
     @Builder
-    public User(Long id, String email, String password, String intro, Status status) {
+    public User(Long id, String email, String password, String intro, Status status, Integer verificationCode) {
         this.id = id;
         this.email = email;
         this.password = password;
         this.intro = intro;
         this.status = status == null? Status.TEMPORARY.ordinal() : status.ordinal();
+        this.verificationCode = verificationCode == null? new Random(System.currentTimeMillis()).nextInt(900000) + 100000 : verificationCode;
+    }
+
+    public void activateStatus() {
+        if (this.status == Status.ACTIVATE.ordinal()) {
+            throw new RuntimeException("이미 활성화된 계정입니다.");
+        }
+        this.status = Status.ACTIVATE.ordinal();
+    }
+
+    public boolean checkVerificationCode(int inputCode) {
+        return this.getVerificationCode() == inputCode;
     }
 }

--- a/src/main/java/com/echo/echo/security/config/SecurityConfig.java
+++ b/src/main/java/com/echo/echo/security/config/SecurityConfig.java
@@ -53,7 +53,7 @@ public class SecurityConfig {
 
                 .authorizeExchange(authorizeExchangeSpec -> authorizeExchangeSpec
                         .pathMatchers(HttpMethod.GET,"/auth").permitAll()
-                        .pathMatchers(HttpMethod.POST, "/users/signup", "/auth/**").permitAll()
+                        .pathMatchers(HttpMethod.POST, "/users/signup", "/users/activate/**", "/auth/**").permitAll()
                         .anyExchange().authenticated()
                 )
                 .addFilterAt(authenticationWebFilter(), SecurityWebFiltersOrder.AUTHENTICATION)

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -12,3 +12,6 @@ jwt.secret=${JWT_SECRET}
 jwt.time.access=${JWT_ACCESS_TIME}
 jwt.time.refresh=${JWT_REFRESH_TIME}
 
+spring.mail.username=${MAIL_USER}
+spring.mail.password=${MAIL_PASSWORD}
+

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -3,7 +3,8 @@ create table if not exists user (
     email varchar(50),
     password varchar(255),
     intro varchar(100),
-    status int(1)
+    status int(1),
+    verification_code int(6)
 );
 
 create table if not exists space (


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가

### 반영 브랜치
ex) feat/login -> dev
feat/mail

### 변경 사항
ex) 로그인 시, 구글 소셜 로그인 기능을 추가했습니다.
- 회원가입 시 인증번호 생성 및 메일 전송, 인증번호로 계정 활성화하는 기능 구현

### 테스트 결과
ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다.

계정 활성화
![image](https://github.com/user-attachments/assets/6ded6491-4304-429e-aa6f-d7cb71414753)

이미 활성화된 계정일 경우
![image](https://github.com/user-attachments/assets/0f8cb1ff-5bcb-4f35-9602-67359ecddd6b)

### 특이사항
- .env 파일이 변경되었습니다 반드시 설정 적용 후 확인 부탁드립니다.