### PR TITLE
[Feat] 채널 구분 및 입장, 퇴장 메시지 중개

### DIFF
--- a/src/main/java/com/echo/echo/common/TimeStamp.java
+++ b/src/main/java/com/echo/echo/common/TimeStamp.java
@@ -1,5 +1,6 @@
 package com.echo.echo.common;
 
+import lombok.Getter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.relational.core.mapping.Column;
@@ -7,7 +8,8 @@ import org.springframework.data.relational.core.mapping.Table;
 
 import java.time.LocalDateTime;
 
-@Table(name = "TimeStamp")
+//@Table(name = "TimeStamp")
+@Getter
 public class TimeStamp {
 
     @CreatedDate

--- a/src/main/java/com/echo/echo/domain/text/TextService.java
+++ b/src/main/java/com/echo/echo/domain/text/TextService.java
@@ -1,13 +1,42 @@
 package com.echo.echo.domain.text;
 
+import com.echo.echo.domain.text.dto.TextRequest;
+import com.echo.echo.domain.text.dto.TextResponse;
+import com.echo.echo.domain.text.entity.Text;
 import com.echo.echo.domain.text.repository.TextRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.socket.WebSocketSession;
+import reactor.core.publisher.Mono;
+import reactor.core.publisher.Sinks;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 @Service
 @RequiredArgsConstructor
 public class TextService {
 
     private final TextRepository repository;
+    private final Map<Long, Sinks.Many<String>> channelSinks = new ConcurrentHashMap<>();
+    private final Map<Long, Map<String, WebSocketSession>> channelSessions = new ConcurrentHashMap<>();
 
+    public Sinks.Many<String> getSink(Long channelId) {
+        return channelSinks.compute(channelId, (id, existingSink) -> {
+            if (existingSink == null || existingSink.currentSubscriberCount() == 0) {
+                return Sinks.many().multicast().onBackpressureBuffer();
+            }
+            return existingSink;
+        });
+    }
+
+    public Map<String, WebSocketSession> getSessions(Long channelId) {
+        return channelSessions.computeIfAbsent(channelId, id -> new ConcurrentHashMap<>());
+    }
+
+    public Mono<TextResponse> sendText(TextRequest request, String username, Long userId, Long channelId) {
+        Text text = new Text(request, username, userId, channelId);
+        return repository.save(text)
+                .map(TextResponse::new);
+    }
 }

--- a/src/main/java/com/echo/echo/domain/text/dto/TextResponse.java
+++ b/src/main/java/com/echo/echo/domain/text/dto/TextResponse.java
@@ -1,13 +1,12 @@
 package com.echo.echo.domain.text.dto;
 
-import io.r2dbc.spi.Row;
+import com.echo.echo.domain.text.entity.Text;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-import java.time.Instant;
-import java.util.Objects;
+import java.time.LocalDateTime;
 
 @Getter
 @Setter
@@ -18,19 +17,14 @@ public class TextResponse {
     private Long id;
     private Long channelId;
     private String contents;
-    private Long userId;
-    private Instant createdAt;
+    private String username;
+    private LocalDateTime createdAt;
 
-    public TextResponse(Row row) {
-
-        this.setId(row.get("text_id", Long.class));
-        this.setChannelId(row.get("channel_id", Long.class));
-        this.setContents(row.get("contents", String.class));
-        this.setUserId(row.get("user_id", Long.class));
-        this.setCreatedAt(row.get("created_at", Instant.class));
-    }
-
-    public boolean isNotFromUser(Long userId) {
-        return !Objects.equals(this.userId, userId);
+    public TextResponse(Text text) {
+        this.id = text.getId();
+        this.contents = text.getContents();
+        this.channelId = text.getChannelId();
+        this.username = text.getUsername();
+        this.createdAt = text.getCreatedAt();
     }
 }

--- a/src/main/java/com/echo/echo/domain/text/entity/Text.java
+++ b/src/main/java/com/echo/echo/domain/text/entity/Text.java
@@ -3,21 +3,12 @@ package com.echo.echo.domain.text.entity;
 import com.echo.echo.common.TimeStamp;
 import com.echo.echo.domain.channel.entity.Channel;
 import com.echo.echo.domain.text.dto.TextRequest;
-import com.echo.echo.domain.user.entity.User;
-import io.r2dbc.spi.Row;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.Id;
-import org.springframework.data.annotation.Transient;
 import org.springframework.data.relational.core.mapping.Column;
-import reactor.core.publisher.Mono;
-
-import javax.swing.plaf.PanelUI;
-import java.util.Objects;
-import java.util.UUID;
-import java.util.concurrent.ThreadLocalRandom;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
@@ -26,34 +17,21 @@ public class Text extends TimeStamp {
     private Long id;
     @Column
     private String contents;
-    private Long userId;
+    private String username;
     private Long channelId;
-    @Transient
-    private User user;
-    @Transient
-    private Channel channel;
+    private Long userId;
 
     @Builder
-    public Text(String contents, User user, Channel channel) {
+    public Text(String contents, String username, Channel channel) {
         this.contents = contents;
-        this.userId = user.getId();
+        this.username = username;
         this.channelId = channel.getId();
-        this.user = user;
-        this.channel = channel;
     }
 
-    public Text(TextRequest request) {
+    public Text(TextRequest request, String username, Long userId, Long channelId) {
         this.contents = request.getContents();
-        this.userId = 1L;
-        this.channelId = 1L;
-        this.user = null;
-        this.channel = null;
-    }
-
-    public Text(Row row) {
-        this.id = row.get("id", Long.class);
-        this.contents = row.get("contents", String.class);
-        this.userId = row.get("userId", Long.class);
-        this.channelId = row.get("channelId", Long.class);
+        this.channelId = channelId;
+        this.username = username;
+        this.userId = userId;
     }
 }

--- a/src/main/java/com/echo/echo/security/jwt/JwtProvider.java
+++ b/src/main/java/com/echo/echo/security/jwt/JwtProvider.java
@@ -112,7 +112,7 @@ public class JwtProvider {
                 });
     }
 
-    private Claims getClaims(String token) {
+    public Claims getClaims(String token) {
         return Jwts.parser().verifyWith((SecretKey) key).build().parseSignedClaims(token).getPayload();
     }
 }

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -37,6 +37,7 @@ create table if not exists space_member (
 create table if not exists text (
     id bigint primary key auto_increment,
     contents text(1000) not null,
+    username varchar(50) not null,
     user_id bigint not null,
     channel_id bigint not null,
     created_at timestamp not null,

--- a/src/main/resources/templates/text/index.html
+++ b/src/main/resources/templates/text/index.html
@@ -1,82 +1,285 @@
 <!DOCTYPE html>
 <html lang="en">
+
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Commeow Chat</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            margin: 0;
+            padding: 0;
+            display: flex;
+            flex-direction: column;
+            justify-content: center;
+            align-items: center;
+            height: 100vh;
+            background-color: #f0f0f0;
+        }
+
+        #chat-container {
+            width: 100%;
+            max-width: 1000px;
+            background: #fff;
+            border-radius: 5px;
+            box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+            display: flex;
+            flex-direction: column;
+            height: 80vh;
+            overflow: auto;
+        }
+
+        #message-list {
+            flex-grow: 1;
+            height: 1000px;
+            padding: 20px;
+            border-bottom: 1px solid #ddd;
+        }
+
+        .message {
+            padding: 10px;
+            margin-bottom: 10px;
+            border-radius: 5px;
+            background: #e1ffc7;
+        }
+
+        .message .username {
+            font-weight: bold;
+            margin-right: 10px;
+            margin-bottom: 5px;
+        }
+
+        .message .timestamp {
+            font-size: 0.8em;
+            color: #888;
+            margin-top: 5px;
+        }
+
+        #input-container {
+            width: 100%;
+            max-width: 1000px;
+        }
+
+        #message-container {
+            display: flex;
+            padding: 10px;
+            border-top: 1px solid #ddd;
+        }
+
+        #channel-input {
+            margin: 0px 10px 0px auto;
+        }
+
+        #setting-container {
+            display: flex;
+            margin-left: 10px;
+        }
+
+        #connection {
+            display: flex;
+            margin-top: 10px;
+            justify-content: center;
+            align-items: center;
+        }
+
+        input {
+            width: 300px;
+            flex-grow: 1;
+            padding: 10px;
+            border: 1px solid #ddd;
+            border-radius: 5px;
+            margin-right: 10px;
+        }
+
+        #inputMessage {
+            flex-grow: 1;
+            padding: 10px;
+            border: 1px solid #ddd;
+            border-radius: 5px;
+            margin-right: 10px;
+        }
+
+        button {
+            padding: 10px 20px;
+            border: none;
+            background: #4CAF50;
+            color: white;
+            border-radius: 5px;
+            cursor: pointer;
+        }
+
+        button:hover {
+            background: #45a904;
+        }
+    </style>
 </head>
+
 <body>
 <div id="chat-container">
-    <div class="chat-box">
+    <div id="messages-list"></div>
+    <!-- <div>
         <ul id="message-list"></ul>
-        <div id="message-input">
-            <input type="text" id="inputMessage" placeholder="메시지를 입력하세요...">
-            <button id="sendButton">전송</button>
+    </div> -->
+</div>
+<div id="input-container">
+    <div id="message-container">
+        <div class="chat-box">
+            <div id="message-input">
+                <input type="text" id="inputMessage" placeholder="메시지를 입력하세요...">
+                <button id="sendButton">전송</button>
+            </div>
         </div>
     </div>
-    <div id="nickname-input">
-        <input type="text" id="username" placeholder="닉네임을 입력하세요...">
-        <button id="confirmUsername" onclick="confirmUsername()">완료</button>
+    <div id="setting-container">
+        <div id="jwt-input">
+            <input type="text" id="JWT" placeholder="JWT을 입력하세요...">
+            <button id="confirmJWT">완료</button>
+        </div>
+        <div id="channel-input">
+            <input type="text" id="inputChannel" placeholder="메시지를 전송할 채널을 입력하세요...">
+            <button id="confrimChannel">설정</button>
+        </div>
+    </div>
+    <div id="connection">
+        <button id="connect" style="margin-right: 10px;">연결</button>
+        <button id="disconnect">연결 해제</button>
     </div>
 </div>
 </body>
 <script>
-    document.addEventListener("DOMContentLoaded", function() {
-        const chatWebSocket = new WebSocket('ws://localhost:8080/api/text');
-        const inputMessage = document.getElementById('inputMessage');
-        const messageList = document.getElementById('message-list');
-        const usernameInput = document.getElementById("username");
-        const sendButton = document.getElementById("sendButton");
-        const confirmButton = document.getElementById("confirmUsername");
+    document.addEventListener('DOMContentLoaded', (event) => {
+        let chatWebSocket
 
-        chatWebSocket.onopen = function(event) {
-            console.log('소켓 연결 완료', event);
-        }
+        const channelId = document.getElementById("inputChannel")
+        const inputMessage = document.getElementById('inputMessage')
+        const messagesList = document.getElementById('messages-list')
+        const messageList = document.getElementById('message-list')
+        const JWTInput = document.getElementById("JWT")
+        const sendButton = document.getElementById("sendButton")
+        const confirmButton = document.getElementById("confirmJWT")
+        const chatContainer = document.getElementById("chat-container")
 
-        chatWebSocket.onmessage = function(event) {
-            console.log('수신', event);
-            const li = document.createElement('li');
-            li.innerText = event.data;
-            messageList.appendChild(li);
-        };
+        function connectWebSocket(channel, token) {
+            chatWebSocket = new WebSocket(`ws://127.0.0.1:8080/api/text?channel=${channel}&token=${token}`)
+            console.log(chatWebSocket)
 
-        chatWebSocket.onclose = function(event) {
-            console.log('소켓 연결 종료', event);
-            alert('웹소켓이 닫혔습니다! 다시 연결하려면 페이지를 새로고침 해주세요.');
-        };
+            chatWebSocket.onopen = function (event) {
+                console.log('소켓 연결 완료', event)
+            }
 
-        chatWebSocket.onerror = function(event) {
-            console.log('소켓 오류', event);
+            chatWebSocket.onmessage = function (event) {
+                console.log('수신', event)
+                try {
+                    const data = JSON.parse(event.data)
+                    const messageDiv = document.createElement('div')
+                    messageDiv.classList.add('message')
+                    messageDiv.id = data.id
+
+                    const usernameSpan = document.createElement('div')
+                    usernameSpan.classList.add('username')
+                    usernameSpan.textContent = data.username
+
+                    const contentsSpan = document.createElement('div')
+                    contentsSpan.classList.add('contents')
+                    contentsSpan.textContent = data.contents
+
+                    const timestampSpan = document.createElement('div')
+                    timestampSpan.classList.add('timestamp')
+                    timestampSpan.textContent = formatDate(new Date(data.createdAt))
+
+                    messageDiv.appendChild(usernameSpan)
+                    messageDiv.appendChild(contentsSpan)
+                    messageDiv.appendChild(timestampSpan)
+
+                    messagesList.appendChild(messageDiv)
+                } catch (e) {
+                    const joindiv = document.createElement('div')
+                    joindiv.classList.add('join-message')
+                    joindiv.textContent = event.data
+                    messagesList.appendChild(joindiv)
+                }
+                chatContainer.scrollTop = chatContainer.scrollHeight
+            }
+
+            chatWebSocket.onclose = function (event) {
+                console.log('소켓 연결 종료', event)
+                alert('소켓 연결 종료, 다시 연결이 필요하면 새로고침 해주세요.')
+            }
+
+            chatWebSocket.onerror = function (event) {
+                console.log('소켓 오류', event)
+            }
         }
 
         function sendMessage() {
             if (inputMessage.value.trim() === '') {
-                return;
+                return
             }
 
-            const username = usernameInput.value.trim();
-            const messageObject = {
-                username:username,
-                message:inputMessage.value,
-            };
-            chatWebSocket.send(JSON.stringify(messageObject));
-            inputMessage.value = '';
+            const data = {
+                contents: inputMessage.value
+            }
+            console.log(data)
+            chatWebSocket.send(JSON.stringify(data))
+            inputMessage.value = ''
         }
 
-        sendButton.addEventListener('click', sendMessage);
+        function formatDate(date) {
+            const year = date.getFullYear()
+            const month = date.getMonth() + 1
+            const day = date.getDate()
+            const hours = date.getHours()
+            const minutes = date.getMinutes()
 
-        confirmButton.addEventListener('click', function() {
-            if (usernameInput.value.trim() !== '') {
-                usernameInput.disabled = true;
-                confirmButton.disabled = true;
-                confirmButton.style.backgroundColor = "gray";
+            return `${year}-${month}-${day} ${hours}:${minutes}`
+        }
+
+        sendButton.addEventListener('click', sendMessage)
+
+        confirmJWT.addEventListener('click', function () {
+            if (JWTInput.value.trim() !== '') {
+                JWTInput.disabled = true
+                confirmJWT.disabled = true
+                confirmJWT.style.backgroundColor = "gray"
             }
-        });
+        })
 
-        document.getElementById('message-input').addEventListener('submit', function(event) {
-            event.preventDefault();
-            sendMessage();
-        });
-    });
+        connect.addEventListener('click', function () {
+            const channel = channelId.value.trim()
+            const token = JWTInput.value.trim()
+            console.log(token)
+
+            if (token === '') {
+                console.error('토큰 정보를 입력해주세요.')
+                alert('토큰 정보를 입력해주세요.')
+                return
+            }
+
+            try {
+                connectWebSocket(channel, token)
+            } catch (e) {
+                console.error('웹 소켓 연결 실패')
+                alert('웹 소켓 연결 실패')
+            }
+        })
+
+        disconnect.addEventListener('click', function () {
+            if (JWTInput.value.trim !== '') {
+                JWTInput.disabled = false
+                confirmButton.disabled = false
+                confirmButton.style.background = '#4CAF50'
+            }
+
+            chatWebSocket.close()
+        })
+
+        document.getElementById('inputMessage').addEventListener('keypress', function (event) {
+            if (event.key === 'Enter') {
+                sendMessage()
+            }
+        })
+    })
 </script>
+
 </html>


### PR DESCRIPTION
### PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
`feat/textchat-stream`-> `dev`

### 변경 사항
- Sink를 기반으로 채널 구분하여 메시징 처리 로직 구현
- 입장 로그, 퇴장 로그 구현(현재 DB에 저장되지 않음)
- Sink에 구독자(세션)이 0일 경우 Sink는 초기화되어 새로운 Sink로 시작함.
    - Sink에 구독자가 0일 때 소켓 연결이 안되는 오류가 있음. 
- 현재 Sink의 관리 전략은 onBackpressureBuffer로 버퍼 크기 및 드랍 여부는 설정하지 않음.
    - 서버 운영 상황 및 전략에 따라 차후 수정 가능
- 채팅방 퇴장, 오류로 인한 소켓 연결 종료 시 자동 서버에 저장된 세션 정리

### 현 상태 관련 사용 방법 (src - templates - text - index.html 기준)
> ### 1. 로컬에서 바로 실행 시 CORS 오류 발생 -> VS코드에서 라이브 서버 실행 후 적용 가능 
> ### 2. HTTP Request를 통해 사전 JWT 획득 및 채널 생성 필요(메시지 저장 간 채널 ID가 존재하지 않으면 오류 발생)
> ### 3. JWT 및 연결하고자 하는 채널 입력 후 연결 버튼 (완료, 설정 버튼 누르지 않아도 됨)
> ### 4. 이후 메시지 입력
> ### 5. 소켓 통신 간 사용되는 값
> - 소켓 연결 : URI를 통한 채널 ID 및 JWT 토큰 정보
> - 입, 퇴장 메시지 : 문자열
> - 메시지 전송 : contents (TextReques 객체)
> - 메시지 수신 : id, contents, username, createdAt, channelId (테스트 환경에서 channelId는 Html 객체에 부여하지 않음)

### 테스트 결과
> ## 동일 채널에서 소켓 연결 및 채팅 시 입장 시점을 기준으로 메시지 출력 확인
![스크린샷 2024-08-01 194632](https://github.com/user-attachments/assets/a6380236-00cc-4c0c-b603-188f1939a126)

> ## 다른 채널일 때 독립적인 메시징 처리 확인
![스크린샷 2024-08-01 194728](https://github.com/user-attachments/assets/511efd65-011c-4524-bf4b-e73143c3a5c9)
