### PR TITLE
[Feat] 텍스트 채팅 기존 입/장 메시지 처리 제거 및 기존 채팅 로그 로드 구현

### DIFF
--- a/src/main/java/com/echo/echo/domain/text/TextService.java
+++ b/src/main/java/com/echo/echo/domain/text/TextService.java
@@ -5,14 +5,17 @@ import com.echo.echo.domain.text.dto.TextResponse;
 import com.echo.echo.domain.text.entity.Text;
 import com.echo.echo.domain.text.repository.TextRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.socket.WebSocketSession;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.core.publisher.Sinks;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class TextService {
@@ -38,5 +41,10 @@ public class TextService {
         Text text = new Text(request, username, userId, channelId);
         return repository.save(text)
                 .map(TextResponse::new);
+    }
+
+    public Flux<TextResponse> loadTextByChannelId(Long channelId) {
+        Flux<Text> textFlux = repository.findAllByChannelId(channelId).log();
+        return textFlux.map(TextResponse::new);
     }
 }

--- a/src/main/java/com/echo/echo/domain/text/dto/TextResponse.java
+++ b/src/main/java/com/echo/echo/domain/text/dto/TextResponse.java
@@ -1,10 +1,7 @@
 package com.echo.echo.domain.text.dto;
 
 import com.echo.echo.domain.text.entity.Text;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
 import java.time.LocalDateTime;
 

--- a/src/main/java/com/echo/echo/domain/text/entity/Text.java
+++ b/src/main/java/com/echo/echo/domain/text/entity/Text.java
@@ -12,7 +12,7 @@ import org.springframework.data.relational.core.mapping.Column;
 import org.springframework.data.relational.core.mapping.Table;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(value = "text")
+@Table(name = "text")
 @Getter
 public class Text extends TimeStamp {
     @Id

--- a/src/main/java/com/echo/echo/domain/text/repository/TextRepository.java
+++ b/src/main/java/com/echo/echo/domain/text/repository/TextRepository.java
@@ -2,7 +2,9 @@ package com.echo.echo.domain.text.repository;
 
 import com.echo.echo.domain.text.entity.Text;
 import org.springframework.data.repository.reactive.ReactiveCrudRepository;
+import reactor.core.publisher.Flux;
 
 public interface TextRepository extends ReactiveCrudRepository<Text, Long> {
 
+    Flux<Text> findAllByChannelId(Long channelId);
 }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [x] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
> ### feat/textchat-stream-> dev

### 변경 사항
> ### 1. 입/퇴장 메시지 처리 코드 제거
> ###  2. 채널 입장 시 기존 채팅 기록 로드 구현

### 테스트 결과
> ### 1개 채널에 순차적으로 사용자 입장 및 메시징 처리
![스크린샷 2024-08-03 162927](https://github.com/user-attachments/assets/36eb22cf-f0b5-4b40-a240-f9cb146c203d)

> ### 위 테스트에 대한 서버 콘솔 정보
![스크린샷 2024-08-03 162917](https://github.com/user-attachments/assets/54e41c71-50b3-4dab-80d7-e8fd36275b98)