### PR TITLE
[Feat Fix] 사용자 및 스페이스 리스트 조회 기능

### DIFF
--- a/http/space.http
+++ b/http/space.http
@@ -34,6 +34,23 @@ Authorization: Bearer {{accessToken}}
 GET localhost:8080/api/spaces/public
 Authorization: Bearer {{accessToken}}
 
+### get my spaces(자신이 들어가 있는 스페이스 목록 조회)
+GET localhost:8080/api/spaces/my
+Content-Type: application/json
+Authorization: Bearer {{accessToken}}
+
+> {%
+  let responseData = JSON.parse(responseBody);
+  client.global.set("mySpaceId", responseData[0].id);
+%}
+
+### get space members(특정 스페이스 멤버 조회)
+GET localhost:8080/api/spaces/{{spaceId}}/members
+Content-Type: application/json
+Authorization: Bearer {{accessToken}}
+
+
+
 ### delete space
 DELETE localhost:8080/api/spaces/{{spaceId}}
 Authorization: Bearer {{accessToken}}

--- a/src/main/java/com/echo/echo/domain/channel/ChannelFacade.java
+++ b/src/main/java/com/echo/echo/domain/channel/ChannelFacade.java
@@ -2,10 +2,7 @@ package com.echo.echo.domain.channel;
 
 import com.echo.echo.domain.channel.dto.ChannelRequestDto;
 import com.echo.echo.domain.channel.dto.ChannelResponseDto;
-import com.echo.echo.domain.space.entity.Space;
-import com.echo.echo.domain.space.error.SpaceErrorCode;
-import com.echo.echo.domain.space.repository.SpaceRepository;
-import com.echo.echo.common.exception.CustomException;
+import com.echo.echo.domain.space.SpaceService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import reactor.core.publisher.Flux;
@@ -19,10 +16,10 @@ import reactor.core.publisher.Mono;
 public class ChannelFacade {
 
     private final ChannelService channelService;
-    private final SpaceRepository spaceRepository;
+    private final SpaceService spaceService;
 
     public Mono<ChannelResponseDto> createChannel(Long spaceId, ChannelRequestDto requestDto) {
-        return findSpaceById(spaceId)
+        return spaceService.findSpaceById(spaceId)
             .flatMap(space -> channelService.createChannel(spaceId, requestDto));
     }
 
@@ -38,8 +35,4 @@ public class ChannelFacade {
         return channelService.deleteChannel(channelId);
     }
 
-    private Mono<Space> findSpaceById(Long spaceId) {
-        return spaceRepository.findById(spaceId)
-            .switchIfEmpty(Mono.error(new CustomException(SpaceErrorCode.SPACE_NOT_FOUND)));
-    }
 }

--- a/src/main/java/com/echo/echo/domain/channel/ChannelFacade.java
+++ b/src/main/java/com/echo/echo/domain/channel/ChannelFacade.java
@@ -2,6 +2,10 @@ package com.echo.echo.domain.channel;
 
 import com.echo.echo.domain.channel.dto.ChannelRequestDto;
 import com.echo.echo.domain.channel.dto.ChannelResponseDto;
+import com.echo.echo.domain.space.entity.Space;
+import com.echo.echo.domain.space.error.SpaceErrorCode;
+import com.echo.echo.domain.space.repository.SpaceRepository;
+import com.echo.echo.common.exception.CustomException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import reactor.core.publisher.Flux;
@@ -15,9 +19,11 @@ import reactor.core.publisher.Mono;
 public class ChannelFacade {
 
     private final ChannelService channelService;
+    private final SpaceRepository spaceRepository;
 
     public Mono<ChannelResponseDto> createChannel(Long spaceId, ChannelRequestDto requestDto) {
-        return channelService.createChannel(spaceId, requestDto);
+        return findSpaceById(spaceId)
+            .flatMap(space -> channelService.createChannel(spaceId, requestDto));
     }
 
     public Flux<ChannelResponseDto> getChannels(Long spaceId) {
@@ -30,5 +36,10 @@ public class ChannelFacade {
 
     public Mono<Void> deleteChannel(Long channelId) {
         return channelService.deleteChannel(channelId);
+    }
+
+    private Mono<Space> findSpaceById(Long spaceId) {
+        return spaceRepository.findById(spaceId)
+            .switchIfEmpty(Mono.error(new CustomException(SpaceErrorCode.SPACE_NOT_FOUND)));
     }
 }

--- a/src/main/java/com/echo/echo/domain/channel/ChannelService.java
+++ b/src/main/java/com/echo/echo/domain/channel/ChannelService.java
@@ -2,13 +2,10 @@ package com.echo.echo.domain.channel;
 
 import com.echo.echo.common.exception.CustomException;
 import com.echo.echo.domain.channel.error.ChannelErrorCode;
-import com.echo.echo.domain.space.error.SpaceErrorCode;
 import com.echo.echo.domain.channel.dto.ChannelRequestDto;
 import com.echo.echo.domain.channel.dto.ChannelResponseDto;
 import com.echo.echo.domain.channel.entity.Channel;
 import com.echo.echo.domain.channel.repository.ChannelRepository;
-import com.echo.echo.domain.space.entity.Space;
-import com.echo.echo.domain.space.repository.SpaceRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Flux;
@@ -23,14 +20,10 @@ import reactor.core.publisher.Mono;
 public class ChannelService {
 
     private final ChannelRepository channelRepository;
-    private final SpaceRepository spaceRepository;
 
     public Mono<ChannelResponseDto> createChannel(Long spaceId, ChannelRequestDto requestDto) {
-        return findSpaceById(spaceId)
-            .flatMap(space -> {
-                Channel channel = buildChannel(null, spaceId, requestDto);
-                return channelRepository.save(channel);
-            })
+        Channel channel = buildChannel(null, spaceId, requestDto);
+        return channelRepository.save(channel)
             .map(this::toChannelResponseDto);
     }
 
@@ -51,11 +44,6 @@ public class ChannelService {
     public Mono<Void> deleteChannel(Long channelId) {
         return findChannelById(channelId)
             .flatMap(channelRepository::delete);
-    }
-
-    private Mono<Space> findSpaceById(Long spaceId) {
-        return spaceRepository.findById(spaceId)
-            .switchIfEmpty(Mono.error(new CustomException(SpaceErrorCode.SPACE_NOT_FOUND)));
     }
 
     private Mono<Channel> findChannelById(Long channelId) {

--- a/src/main/java/com/echo/echo/domain/space/SpaceController.java
+++ b/src/main/java/com/echo/echo/domain/space/SpaceController.java
@@ -3,6 +3,7 @@ package com.echo.echo.domain.space;
 import com.echo.echo.domain.space.error.SpaceSuccessCode;
 import com.echo.echo.domain.space.dto.SpaceRequestDto;
 import com.echo.echo.domain.space.dto.SpaceResponseDto;
+import com.echo.echo.domain.user.dto.UserResponseDto;
 import com.echo.echo.security.principal.UserPrincipal;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -69,6 +70,11 @@ public class SpaceController {
         @AuthenticationPrincipal UserPrincipal userPrincipal) {
         Long userId = userPrincipal.getUser().getId();
         return spaceFacade.getUserSpaces(userId);
+    }
+
+    @GetMapping("/{spaceId}/members")
+    public Flux<UserResponseDto> getSpaceMembers(@PathVariable Long spaceId) {
+        return spaceFacade.getSpaceMembers(spaceId);
     }
 
 }

--- a/src/main/java/com/echo/echo/domain/space/SpaceController.java
+++ b/src/main/java/com/echo/echo/domain/space/SpaceController.java
@@ -46,7 +46,7 @@ public class SpaceController {
     }
 
     @GetMapping("/{spaceId}")
-    public Mono<ResponseEntity<Object>> getSpaceById(@PathVariable Long spaceId) {
+    public Mono<ResponseEntity<SpaceResponseDto>> getSpaceById(@PathVariable Long spaceId) {
         return spaceFacade.getSpaceById(spaceId)
             .map(ResponseEntity::ok);
     }
@@ -58,7 +58,7 @@ public class SpaceController {
     }
 
     @PostMapping("/join/{uuid}")
-    public Mono<ResponseEntity<Object>> joinSpace(
+    public Mono<ResponseEntity<SpaceResponseDto>> joinSpace(
         @AuthenticationPrincipal UserPrincipal userPrincipal,
         @PathVariable String uuid) {
         return spaceFacade.joinSpace(uuid, userPrincipal.getUser().getId())

--- a/src/main/java/com/echo/echo/domain/space/SpaceController.java
+++ b/src/main/java/com/echo/echo/domain/space/SpaceController.java
@@ -25,8 +25,10 @@ public class SpaceController {
 
     @PostMapping
     public Mono<ResponseEntity<SpaceResponseDto>> createSpace(
+        @AuthenticationPrincipal UserPrincipal userPrincipal,
         @Valid @RequestBody SpaceRequestDto requestDto) {
-        return spaceFacade.createSpace(requestDto)
+        Long userId = userPrincipal.getUser().getId();
+        return spaceFacade.createSpace(requestDto, userId)
             .map(ResponseEntity::ok);
     }
 
@@ -60,6 +62,13 @@ public class SpaceController {
         @PathVariable String uuid) {
         return spaceFacade.joinSpace(uuid, userPrincipal.getUser().getId())
             .map(ResponseEntity::ok);
+    }
+
+    @GetMapping("/my")
+    public Flux<SpaceResponseDto> getMySpaces(
+        @AuthenticationPrincipal UserPrincipal userPrincipal) {
+        Long userId = userPrincipal.getUser().getId();
+        return spaceFacade.getUserSpaces(userId);
     }
 
 }

--- a/src/main/java/com/echo/echo/domain/space/SpaceFacade.java
+++ b/src/main/java/com/echo/echo/domain/space/SpaceFacade.java
@@ -2,6 +2,8 @@ package com.echo.echo.domain.space;
 
 import com.echo.echo.domain.space.dto.SpaceRequestDto;
 import com.echo.echo.domain.space.dto.SpaceResponseDto;
+import com.echo.echo.domain.user.UserFacade;
+import com.echo.echo.domain.user.dto.UserResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import reactor.core.publisher.Flux;
@@ -16,6 +18,7 @@ import reactor.core.publisher.Mono;
 public class SpaceFacade {
 
     private final SpaceService spaceService;
+    private final UserFacade userFacade;
 
     public Mono<SpaceResponseDto> createSpace(SpaceRequestDto requestDto, Long userId) {
         return spaceService.createSpace(requestDto, userId);
@@ -44,4 +47,11 @@ public class SpaceFacade {
     public Flux<SpaceResponseDto> getUserSpaces(Long userId) {
         return spaceService.getUserSpaces(userId);
     }
+
+    public Flux<UserResponseDto> getSpaceMembers(Long spaceId) {
+        return spaceService.getSpaceMembers(spaceId)
+            .flatMap(spaceMember -> userFacade.findUserById(spaceMember.getUserId()));
+    }
+
+
 }

--- a/src/main/java/com/echo/echo/domain/space/SpaceFacade.java
+++ b/src/main/java/com/echo/echo/domain/space/SpaceFacade.java
@@ -2,7 +2,7 @@ package com.echo.echo.domain.space;
 
 import com.echo.echo.domain.space.dto.SpaceRequestDto;
 import com.echo.echo.domain.space.dto.SpaceResponseDto;
-import com.echo.echo.domain.user.UserFacade;
+import com.echo.echo.domain.user.UserService;
 import com.echo.echo.domain.user.dto.UserResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -18,7 +18,7 @@ import reactor.core.publisher.Mono;
 public class SpaceFacade {
 
     private final SpaceService spaceService;
-    private final UserFacade userFacade;
+    private final UserService userService;
 
     public Mono<SpaceResponseDto> createSpace(SpaceRequestDto requestDto, Long userId) {
         return spaceService.createSpace(requestDto, userId);
@@ -50,8 +50,8 @@ public class SpaceFacade {
 
     public Flux<UserResponseDto> getSpaceMembers(Long spaceId) {
         return spaceService.getSpaceMembers(spaceId)
-            .flatMap(spaceMember -> userFacade.findUserById(spaceMember.getUserId()));
+            .flatMap(spaceMember -> userService.findById(spaceMember.getUserId())
+                .map(UserResponseDto::new));
     }
-
 
 }

--- a/src/main/java/com/echo/echo/domain/space/SpaceFacade.java
+++ b/src/main/java/com/echo/echo/domain/space/SpaceFacade.java
@@ -17,8 +17,8 @@ public class SpaceFacade {
 
     private final SpaceService spaceService;
 
-    public Mono<SpaceResponseDto> createSpace(SpaceRequestDto requestDto) {
-        return spaceService.createSpace(requestDto);
+    public Mono<SpaceResponseDto> createSpace(SpaceRequestDto requestDto, Long userId) {
+        return spaceService.createSpace(requestDto, userId);
     }
 
     public Mono<SpaceResponseDto> updateSpace(Long spaceId, SpaceRequestDto requestDto) {
@@ -39,5 +39,9 @@ public class SpaceFacade {
 
     public Mono<SpaceResponseDto> joinSpace(String uuid, Long userId) {
         return spaceService.joinSpace(uuid, userId);
+    }
+
+    public Flux<SpaceResponseDto> getUserSpaces(Long userId) {
+        return spaceService.getUserSpaces(userId);
     }
 }

--- a/src/main/java/com/echo/echo/domain/space/SpaceService.java
+++ b/src/main/java/com/echo/echo/domain/space/SpaceService.java
@@ -86,7 +86,7 @@ public class SpaceService {
             .flatMapMany(existingSpace -> spaceMemberRepository.findAllBySpaceId(spaceId));
     }
 
-    private Mono<Space> findSpaceById(Long spaceId) {
+    public Mono<Space> findSpaceById(Long spaceId) {
         return spaceRepository.findById(spaceId)
             .switchIfEmpty(Mono.error(new CustomException(SpaceErrorCode.SPACE_NOT_FOUND)));
     }

--- a/src/main/java/com/echo/echo/domain/space/SpaceService.java
+++ b/src/main/java/com/echo/echo/domain/space/SpaceService.java
@@ -80,6 +80,12 @@ public class SpaceService {
             );
     }
 
+    public Flux<SpaceMember> getSpaceMembers(Long spaceId) {
+        return spaceRepository.findById(spaceId)
+            .switchIfEmpty(Mono.error(new CustomException(SpaceErrorCode.SPACE_NOT_FOUND)))
+            .flatMapMany(existingSpace -> spaceMemberRepository.findAllBySpaceId(spaceId));
+    }
+
     private Mono<Space> findSpaceById(Long spaceId) {
         return spaceRepository.findById(spaceId)
             .switchIfEmpty(Mono.error(new CustomException(SpaceErrorCode.SPACE_NOT_FOUND)));

--- a/src/main/java/com/echo/echo/domain/space/error/SpaceErrorCode.java
+++ b/src/main/java/com/echo/echo/domain/space/error/SpaceErrorCode.java
@@ -18,6 +18,7 @@ public enum SpaceErrorCode implements BaseCode {
     SPACE_NOT_FOUND(HttpStatus.NOT_FOUND, 404, "스페이스 데이터를 찾을 수 없습니다.", "스페이스 데이터가 존재하지 않습니다."),
     INVALID_SPACE_NAME(HttpStatus.BAD_REQUEST, 5001, "스페이스 이름은 20자 미만이어야 합니다.", "스페이스 이름이 유효하지 않습니다."),
     INVALID_IS_PUBLIC(HttpStatus.BAD_REQUEST, 5002, "공개 여부는 Y 또는 N이어야 합니다.", "공개 여부 값이 유효하지 않습니다."),
+    NO_SPACES_JOINED(HttpStatus.NOT_FOUND, 5003, "가입된 스페이스가 없습니다.", "사용자가 가입한 스페이스가 없습니다."),
     
     ;
 

--- a/src/main/java/com/echo/echo/domain/space/repository/SpaceMemberRepository.java
+++ b/src/main/java/com/echo/echo/domain/space/repository/SpaceMemberRepository.java
@@ -2,6 +2,7 @@ package com.echo.echo.domain.space.repository;
 
 import com.echo.echo.domain.space.entity.SpaceMember;
 import org.springframework.data.repository.reactive.ReactiveCrudRepository;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 /**
@@ -10,5 +11,6 @@ import reactor.core.publisher.Mono;
 
 public interface SpaceMemberRepository extends ReactiveCrudRepository<SpaceMember, Long> {
     Mono<SpaceMember> findByUserIdAndSpaceId(Long userId, Long spaceId);
+    Flux<SpaceMember> findAllByUserId(Long userId);
     Mono<Void> deleteBySpaceId(Long spaceId);
 }

--- a/src/main/java/com/echo/echo/domain/space/repository/SpaceMemberRepository.java
+++ b/src/main/java/com/echo/echo/domain/space/repository/SpaceMemberRepository.java
@@ -13,4 +13,6 @@ public interface SpaceMemberRepository extends ReactiveCrudRepository<SpaceMembe
     Mono<SpaceMember> findByUserIdAndSpaceId(Long userId, Long spaceId);
     Flux<SpaceMember> findAllByUserId(Long userId);
     Mono<Void> deleteBySpaceId(Long spaceId);
+    Flux<SpaceMember> findAllBySpaceId(Long spaceId);
+
 }


### PR DESCRIPTION
### PR 타입
- [x] 기능 추가
- [x] 기능 수정

### 반영 브랜치
ex) feat-fix/space -> dev

### 변경 사항
스페이스 생성했을 때 그사람이 원래는 그 스페이스에 없는걸로 나왔는데, 이제는 생성하면 바로 그 스페이스에 들어가게 fix
자신의 스페이스만 볼 수 있도록 조회 기능 수정(사용자가 로그인 시 자신의 스페이스만 볼 수 있도록 API를 수정)
스페이스 멤버 조회 API 추가(스페이스에 가입한 사용자들의 목록을 반환하는 API를 추가)


### 테스트 결과

![자신이 들어가있는 스페이스만 보이게(spaces_my) ](https://github.com/user-attachments/assets/120533c6-6e46-483a-abf0-de2d2e16c59d)
//자신의 스페이스만 볼 수 있는 api

![가입된 스페이스가 없으면 예외처리](https://github.com/user-attachments/assets/8e38585e-db7e-482c-aac3-ac64b26babd7)
//가입된 스페이스가 없을 때

![스페이스 멤버조회 잘나옴1](https://github.com/user-attachments/assets/a1d0b3d5-734c-4bd8-af2f-34d163617411)
//스페이스 멤버 조회 api

![스페이스 멤버조회 예외처리 스페이스번호 없을때](https://github.com/user-attachments/assets/c24cf3b6-0a21-4923-8c9e-3b09de0af027)
//스페이스 id가 db상에 없을 때
