### PR TITLE
[Refactor] Text 도메인 DB 변경 (MariaDB → MongoDB)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-r2dbc'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis-reactive'
     runtimeOnly 'org.mariadb:r2dbc-mariadb'
+    implementation 'org.springframework.boot:spring-boot-starter-data-mongodb-reactive'
 
     // WebFlux
     implementation 'org.springframework.boot:spring-boot-starter-webflux'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,7 @@ services:
       - 27017:27017
     volumes:
       - ~/mongodb:/data/db
+      - ./mongo-init-script.sh:/docker-entrypoint-initdb.d/script.sh
     environment:
       - MONGO_INITDB_ROOT_USERNAME=root
       - MONGO_INITDB_ROOT_PASSWORD=1234

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,3 +15,33 @@ services:
     image: redis
     ports:
       - 6379:6379
+  mongodb:
+    image: mongo
+    restart: always
+    ports:
+      - 27017:27017
+    volumes:
+      - ~/mongodb:/data/db
+    environment:
+      - MONGO_INITDB_ROOT_USERNAME=root
+      - MONGO_INITDB_ROOT_PASSWORD=1234
+      - MONGO_INITDB_DATABASE=echo
+  mongo-express:
+    image: mongo-express
+    restart: always
+    ports:
+      - 8081:8081
+    environment:
+      ME_CONFIG_MONGODB_ADMINUSERNAME: root
+      ME_CONFIG_MONGODB_ADMINPASSWORD: 1234
+      ME_CONFIG_MONGODB_URL: mongodb://root:1234@mongodb:27017
+      ME_CONFIG_BASICAUTH_USERNAME: admin
+      ME_CONFIG_BASICAUTH_PASSWORD: password
+  nginx:
+    image: nginx
+    ports:
+      - "5000:80"
+    volumes:
+      - ./nginx.conf:/etc/nginx/nginx.conf
+    extra_hosts:
+      - host.docker.internal:host-gateway

--- a/mongo-init-script.sh
+++ b/mongo-init-script.sh
@@ -1,0 +1,5 @@
+mongosh -u root -p 1234 <<EOF
+use echo
+db.createUser({user: "root", pwd: "1234", roles: [{ role: "readWrite", db: "echo" }]})
+db.text.insert({contents:"test"})
+EOF

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,48 @@
+worker_processes 1;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    include       mime.types;
+    default_type  application/octet-stream;
+
+    sendfile        on;
+    keepalive_timeout  65;
+
+    upstream backend_app {
+        server host.docker.internal:3000;
+    }
+
+    upstream backend_api {
+        server host.docker.internal:8080;
+    }
+
+    server {
+        listen 80;
+        listen [::]:80;
+
+        location / {
+            proxy_pass http://backend_app;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+        location /api {
+            rewrite ^/api/(.*) /$1 break;
+            proxy_pass http://backend_api;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection 'upgrade';
+            proxy_set_header Host $host;
+            proxy_cache_bypass $http_upgrade;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+    }
+}

--- a/src/main/java/com/echo/echo/config/MongoDBConfig.java
+++ b/src/main/java/com/echo/echo/config/MongoDBConfig.java
@@ -1,0 +1,25 @@
+package com.echo.echo.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.mongodb.core.ReactiveMongoTemplate;
+import org.springframework.data.mongodb.core.convert.DefaultMongoTypeMapper;
+import org.springframework.data.mongodb.core.convert.MappingMongoConverter;
+import org.springframework.data.mongodb.core.mapping.MongoMappingContext;
+import org.springframework.data.mongodb.repository.config.EnableReactiveMongoRepositories;
+
+@Configuration
+@EnableReactiveMongoRepositories(basePackages = "com.echo.echo.domain.text.repository")
+@RequiredArgsConstructor
+public class MongoDBConfig {
+
+    private final MongoMappingContext mongoMappingContext;
+
+    @Bean
+    public MappingMongoConverter mappingMongoConverter() {
+        MappingMongoConverter converter = new MappingMongoConverter(ReactiveMongoTemplate.NO_OP_REF_RESOLVER, mongoMappingContext);
+        converter.setTypeMapper(new DefaultMongoTypeMapper(null));
+        return converter;
+    }
+}

--- a/src/main/java/com/echo/echo/domain/text/TextService.java
+++ b/src/main/java/com/echo/echo/domain/text/TextService.java
@@ -44,7 +44,7 @@ public class TextService {
     }
 
     public Flux<TextResponse> loadTextByChannelId(Long channelId) {
-        Flux<Text> textFlux = repository.findAllByChannelId(channelId).log();
-        return textFlux.map(TextResponse::new);
+        return repository.findAllByChannelId(channelId)
+                        .map(TextResponse::new);
     }
 }

--- a/src/main/java/com/echo/echo/domain/text/dto/TextResponse.java
+++ b/src/main/java/com/echo/echo/domain/text/dto/TextResponse.java
@@ -1,7 +1,10 @@
 package com.echo.echo.domain.text.dto;
 
 import com.echo.echo.domain.text.entity.Text;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import java.time.LocalDateTime;
 
@@ -11,7 +14,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 public class TextResponse {
 
-    private Long id;
+    private String id;
     private Long channelId;
     private String contents;
     private String username;

--- a/src/main/java/com/echo/echo/domain/text/entity/Text.java
+++ b/src/main/java/com/echo/echo/domain/text/entity/Text.java
@@ -1,39 +1,31 @@
 package com.echo.echo.domain.text.entity;
 
-import com.echo.echo.common.TimeStamp;
-import com.echo.echo.domain.channel.entity.Channel;
 import com.echo.echo.domain.text.dto.TextRequest;
 import lombok.AccessLevel;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.Id;
-import org.springframework.data.relational.core.mapping.Column;
-import org.springframework.data.relational.core.mapping.Table;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.time.LocalDateTime;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "text")
 @Getter
-public class Text extends TimeStamp {
+@Document(collection = "text")
+public class Text {
     @Id
-    private Long id;
-    @Column
+    private String id;
     private String contents;
     private String username;
     private Long channelId;
     private Long userId;
-
-    @Builder
-    public Text(String contents, String username, Channel channel) {
-        this.contents = contents;
-        this.username = username;
-        this.channelId = channel.getId();
-    }
+    private LocalDateTime createdAt;
 
     public Text(TextRequest request, String username, Long userId, Long channelId) {
         this.contents = request.getContents();
         this.channelId = channelId;
         this.username = username;
         this.userId = userId;
+        this.createdAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/com/echo/echo/domain/text/repository/TextRepository.java
+++ b/src/main/java/com/echo/echo/domain/text/repository/TextRepository.java
@@ -1,10 +1,13 @@
 package com.echo.echo.domain.text.repository;
 
 import com.echo.echo.domain.text.entity.Text;
-import org.springframework.data.repository.reactive.ReactiveCrudRepository;
+import org.springframework.data.mongodb.repository.Query;
+import org.springframework.data.mongodb.repository.ReactiveMongoRepository;
+import org.springframework.stereotype.Repository;
 import reactor.core.publisher.Flux;
 
-public interface TextRepository extends ReactiveCrudRepository<Text, Long> {
+@Repository
+public interface TextRepository extends ReactiveMongoRepository<Text, String> {
 
     Flux<Text> findAllByChannelId(Long channelId);
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -8,7 +8,7 @@ spring.r2dbc.password=${MARIADB_PASSWORD}
 
 logging.level.org.springframework.r2dbc=debug
 
-spring.data.mongodb.uri=${MONGODB_LOCAL_URL}
+spring.data.mongodb.uri=${MONGODB_URL}
 spring.data.mongodb.database=${MONGODB_DATABASE}
 spring.data.mongodb.port=${MONGODB_PORT}
 spring.data.mongodb.host=${MONGODB_HOST}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -9,9 +9,6 @@ spring.r2dbc.password=${MARIADB_PASSWORD}
 logging.level.org.springframework.r2dbc=debug
 
 spring.data.mongodb.uri=${MONGODB_URL}
-spring.data.mongodb.database=${MONGODB_DATABASE}
-spring.data.mongodb.port=${MONGODB_PORT}
-spring.data.mongodb.host=${MONGODB_HOST}
 
 jwt.secret=${JWT_SECRET}
 jwt.time.access=${JWT_ACCESS_TIME}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -8,6 +8,11 @@ spring.r2dbc.password=${MARIADB_PASSWORD}
 
 logging.level.org.springframework.r2dbc=debug
 
+spring.data.mongodb.uri=${MONGODB_LOCAL_URL}
+spring.data.mongodb.database=${MONGODB_DATABASE}
+spring.data.mongodb.port=${MONGODB_PORT}
+spring.data.mongodb.host=${MONGODB_HOST}
+
 jwt.secret=${JWT_SECRET}
 jwt.time.access=${JWT_ACCESS_TIME}
 jwt.time.refresh=${JWT_REFRESH_TIME}


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [x] 기능 삭제
- [ ] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
ex) infra/textchat-db -> dev

### 변경 사항
- Text 도메인 DB 변경(MariaDB -> MongoDB)
> 쉽게 비대해질 수 있는 실시간 채팅의 DB로서 기존에는 초기 개발환경 통일을 위해 MariaDB를 사용했으나, 기본 기능 구현 후 확장성과 비정형적인 내부 컨텐츠(내용) 처리에 용이한 MongoDB로 변경
- Reactive MongoDB Gradle 의존성 주입
> Echo의 어플리케이션의 기반이 WebFlux임에 따라 MongoDB Reactive 의존성 주입
- DB 변경에 따른 Entity ID 필드의 타입 변경
> MongoDB의 ObjectID를 사용하기 위해 Text Entity의 ID를 `Long` → `String` 타입으로 변경
- MongoDB Atlas 연결 확인 완료
> 최종적으로 MongoDB Atlas를 사용할 예정이기 때문에 관련 DB 설정 및 정상 데이터 입출력 확인
- 로컬 개발을 위해 Docker-compose 파일 작성
> MongoDB Atlas를 사용할 것이나, 로컬 환경에서 타 팀원 간의 개발 간 충돌을 대비하여 Docker 환경에서 추가 개발
- 기존 기능 정상 작동 확인

### 테스트 결과
> ### 1. 데이터 입력(채팅 입력)
![스크린샷 2024-08-06 215740](https://github.com/user-attachments/assets/c2598074-b6a2-4234-a8a4-83064d5604da)

<br>

> ### 2. 데이터 출력(채팅방 입장 시 기존 로그 반환)
![스크린샷 2024-08-06 215800](https://github.com/user-attachments/assets/ff2e2c32-9f80-493a-8bcd-5bfd628c4b0d)