### PR TITLE
[Feat] Redis Pub/Sub 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,9 +25,9 @@ repositories {
 
 dependencies {
     // R2DBC
+    runtimeOnly 'org.mariadb:r2dbc-mariadb'
     implementation 'org.springframework.boot:spring-boot-starter-data-r2dbc'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis-reactive'
-    runtimeOnly 'org.mariadb:r2dbc-mariadb'
     implementation 'org.springframework.boot:spring-boot-starter-data-mongodb-reactive'
 
     // WebFlux
@@ -43,6 +43,7 @@ dependencies {
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
     implementation 'org.json:json:20240303'
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
     compileOnly group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.12.6'
     runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.12.6'
     runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.12.6'

--- a/build.gradle
+++ b/build.gradle
@@ -25,9 +25,9 @@ repositories {
 
 dependencies {
     // R2DBC
+    runtimeOnly 'org.mariadb:r2dbc-mariadb'
     implementation 'org.springframework.boot:spring-boot-starter-data-r2dbc'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis-reactive'
-    runtimeOnly 'org.mariadb:r2dbc-mariadb'
     implementation 'org.springframework.boot:spring-boot-starter-data-mongodb-reactive'
 
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
@@ -45,6 +45,7 @@ dependencies {
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
     implementation 'org.json:json:20240303'
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
     compileOnly group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.12.6'
     runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.12.6'
     runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.12.6'

--- a/src/main/java/com/echo/echo/common/redis/RedisConst.java
+++ b/src/main/java/com/echo/echo/common/redis/RedisConst.java
@@ -1,7 +1,10 @@
 package com.echo.echo.common.redis;
 
-public class RedisConst {
+import lombok.Getter;
 
-    public static final String TEXT_CHANNEL_PREFIX = "text";
+@Getter
+public enum RedisConst {
+
+    TEXT
 
 }

--- a/src/main/java/com/echo/echo/common/redis/RedisConst.java
+++ b/src/main/java/com/echo/echo/common/redis/RedisConst.java
@@ -1,0 +1,7 @@
+package com.echo.echo.common.redis;
+
+public class RedisConst {
+
+    public static final String TEXT_CHANNEL_PREFIX = "text";
+
+}

--- a/src/main/java/com/echo/echo/common/redis/RedisListener.java
+++ b/src/main/java/com/echo/echo/common/redis/RedisListener.java
@@ -3,54 +3,20 @@ package com.echo.echo.common.redis;
 import com.echo.echo.domain.text.controller.TextWebSocketHandler;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.redis.connection.ReactiveSubscription;
-import org.springframework.data.redis.listener.ChannelTopic;
-import org.springframework.data.redis.listener.ReactiveRedisMessageListenerContainer;
 import org.springframework.stereotype.Component;
-import reactor.core.Disposable;
-import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
-import reactor.core.publisher.Sinks;
-
-import java.util.concurrent.ConcurrentHashMap;
 
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class RedisListener {
 
-    private final ReactiveRedisMessageListenerContainer listenerContainer;
     private final TextWebSocketHandler textWebSocketHandler;
-    private final Sinks.Many<ReactiveSubscription.Message<String, String>> sink = Sinks.many().multicast().onBackpressureBuffer();
-    private final ConcurrentHashMap<String, Disposable> topicSubscription = new ConcurrentHashMap<>();
-
-    public Mono<Void> addTopic(String topicName) {
-        ChannelTopic topic = new ChannelTopic(topicName);
-        Disposable subscription = listenerContainer.receive(topic)
-                .doOnNext(sink::tryEmitNext)
-                .subscribe();
-        topicSubscription.putIfAbsent(topicName, subscription);
-        return Mono.empty();
-    }
-
-    public Mono<Void> removeTopic(String topicName) {
-        Disposable subscription = topicSubscription.remove(topicName);
-        if (subscription != null) {
-            return Mono.fromRunnable(subscription::dispose)
-                            .doOnTerminate(() -> log.info("{} topic 구독 해지", topicName)).then();
-        } else {
-            return Mono.empty();
-        }
-    }
-
-    public Flux<ReactiveSubscription.Message<String, String>> getMessageFlux() {
-        return sink.asFlux();
-    }
 
     // Redis에서 Listen되고 있는 토픽이 추가될 때 case 추가하여 메시징 처리 로직으로 연결
-    public Mono<Void> handleMessage(String topic, String body) {
+    public Mono<Void> handleMessage(RedisConst topic, String body) {
         switch (topic) {
-            case RedisConst.TEXT_CHANNEL_PREFIX:
+            case TEXT:
                 return textWebSocketHandler.sendText(body).then();
             default:
                 return Mono.empty();

--- a/src/main/java/com/echo/echo/common/redis/RedisListener.java
+++ b/src/main/java/com/echo/echo/common/redis/RedisListener.java
@@ -1,0 +1,59 @@
+package com.echo.echo.common.redis;
+
+import com.echo.echo.domain.text.controller.TextWebSocketHandler;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.connection.ReactiveSubscription;
+import org.springframework.data.redis.listener.ChannelTopic;
+import org.springframework.data.redis.listener.ReactiveRedisMessageListenerContainer;
+import org.springframework.stereotype.Component;
+import reactor.core.Disposable;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.core.publisher.Sinks;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RedisListener {
+
+    private final ReactiveRedisMessageListenerContainer listenerContainer;
+    private final TextWebSocketHandler textWebSocketHandler;
+    private final Sinks.Many<ReactiveSubscription.Message<String, String>> sink = Sinks.many().multicast().onBackpressureBuffer();
+    private final ConcurrentHashMap<String, Disposable> topicSubscription = new ConcurrentHashMap<>();
+
+    public Mono<Void> addTopic(String topicName) {
+        ChannelTopic topic = new ChannelTopic(topicName);
+        Disposable subscription = listenerContainer.receive(topic)
+                .doOnNext(sink::tryEmitNext)
+                .subscribe();
+        topicSubscription.putIfAbsent(topicName, subscription);
+        return Mono.empty();
+    }
+
+    public Mono<Void> removeTopic(String topicName) {
+        Disposable subscription = topicSubscription.remove(topicName);
+        if (subscription != null) {
+            return Mono.fromRunnable(subscription::dispose)
+                            .doOnTerminate(() -> log.info("{} topic 구독 해지", topicName)).then();
+        } else {
+            return Mono.empty();
+        }
+    }
+
+    public Flux<ReactiveSubscription.Message<String, String>> getMessageFlux() {
+        return sink.asFlux();
+    }
+
+    // Redis에서 Listen되고 있는 토픽이 추가될 때 case 추가하여 메시징 처리 로직으로 연결
+    public Mono<Void> handleMessage(String topic, String body) {
+        switch (topic) {
+            case RedisConst.TEXT_CHANNEL_PREFIX:
+                return textWebSocketHandler.sendText(body).then();
+            default:
+                return Mono.empty();
+        }
+    }
+}

--- a/src/main/java/com/echo/echo/common/redis/RedisPublisher.java
+++ b/src/main/java/com/echo/echo/common/redis/RedisPublisher.java
@@ -1,0 +1,28 @@
+package com.echo.echo.common.redis;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.ReactiveRedisTemplate;
+import org.springframework.data.redis.listener.ChannelTopic;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RedisPublisher {
+
+    private final ReactiveRedisTemplate<String, Object> reactiveRedisTemplate;
+
+    public <T> Mono<Void> publish(ChannelTopic topic, T t) {
+        return Mono.defer(() -> reactiveRedisTemplate.convertAndSend(topic.getTopic(), t)
+                .doOnSuccess(success -> {
+                    if (success > 0)
+                        log.info("메시지 퍼블리싱 성공");
+                    else
+                        log.warn("퍼블리싱 메시지를 받을 구독자가 없음");
+                })
+                .doOnError(throwable -> log.error("메시지 퍼블리싱 오류", throwable))
+                .then());
+    }
+}

--- a/src/main/java/com/echo/echo/common/redis/RedisService.java
+++ b/src/main/java/com/echo/echo/common/redis/RedisService.java
@@ -4,43 +4,41 @@ import com.echo.echo.common.exception.CustomException;
 import com.echo.echo.common.exception.codes.CommonErrorCode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.redis.core.ReactiveRedisOperations;
+import org.springframework.data.redis.core.ReactiveRedisTemplate;
 import org.springframework.stereotype.Component;
 import reactor.core.publisher.Mono;
 
 import java.time.Duration;
-import java.util.function.Consumer;
 
 @Component
 @RequiredArgsConstructor
 public class RedisService {
 
-    private final ReactiveRedisOperations<String, Object> redisOps;
+    private final ReactiveRedisTemplate<String, Object> redisTemplate;
     private final ObjectMapper objectMapper;
 
     public Mono<String> getValue(String key) {
-        return redisOps.opsForValue().get(key).map(String::valueOf);
+        return redisTemplate.opsForValue().get(key).map(String::valueOf);
     }
 
     public Mono<Boolean> setValue(String key, Object value) {
-        return redisOps.opsForValue().set(key, value);
+        return redisTemplate.opsForValue().set(key, value);
     }
 
     public Mono<Boolean> setValue(String key, Object value, Duration duration) {
-        return redisOps.opsForValue().set(key, value)
-                .then(redisOps.expire(key, duration));
+        return redisTemplate.opsForValue().set(key, value)
+                .then(redisTemplate.expire(key, duration));
     }
 
     public <T> Mono<T> getCacheValueGeneric(String key, Class<T> clazz) {
-        return redisOps.opsForValue().get(key)
+        return redisTemplate.opsForValue().get(key)
                 .switchIfEmpty(Mono.empty())
                 .flatMap(value -> Mono.just(objectMapper.convertValue(value, clazz)));
     }
 
     public Mono<Void> deleteValue(String key) {
-        return redisOps.delete(key)
+        return redisTemplate.delete(key)
                 .doOnError(err -> Mono.error(new CustomException(CommonErrorCode.NOT_FOUND_DATA)))
                 .then();
     }
-
 }

--- a/src/main/java/com/echo/echo/common/util/ObjectStringConverter.java
+++ b/src/main/java/com/echo/echo/common/util/ObjectStringConverter.java
@@ -1,0 +1,27 @@
+package com.echo.echo.common.util;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Configuration;
+import reactor.core.publisher.Mono;
+
+import java.util.Map;
+
+@Slf4j
+@RequiredArgsConstructor
+@Configuration(proxyBeanMethods = false)
+public class ObjectStringConverter {
+
+    private final ObjectMapper mapper;
+
+    public  <T> Mono<String> objectToString(T object) {
+        return Mono.fromCallable(() -> mapper.writeValueAsString(object)).log()
+                .doOnError(throwable -> log.error("[{}] 객체를 문자열로 변환중 오류 발생.", object));
+    }
+
+    public <T> Mono<T> stringToObject(String payload, Class<T> clazz) {
+        return Mono.fromCallable(() -> mapper.readValue(payload, clazz))
+                .doOnError(throwable -> log.error("[{}] 문자열을 '{}' 객체로 변환중 오류 발생.", payload, clazz.getSimpleName()));
+    }
+}

--- a/src/main/java/com/echo/echo/config/RedisConfig.java
+++ b/src/main/java/com/echo/echo/config/RedisConfig.java
@@ -1,46 +1,70 @@
 package com.echo.echo.config;
 
+import com.echo.echo.common.redis.RedisConst;
+import com.echo.echo.common.redis.RedisListener;
 import com.echo.echo.domain.user.entity.RefreshToken;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.ApplicationRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.ReactiveRedisConnectionFactory;
-import org.springframework.data.redis.connection.RedisConnectionFactory;
-import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
-import org.springframework.data.redis.core.ReactiveRedisOperations;
 import org.springframework.data.redis.core.ReactiveRedisTemplate;
-import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.listener.ReactiveRedisMessageListenerContainer;
 import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
 import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.RedisSerializationContext;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
+import reactor.core.publisher.Flux;
 
+import java.util.List;
+
+@Slf4j
 @Configuration
 @EnableRedisRepositories(basePackageClasses = RefreshToken.class)
+@RequiredArgsConstructor
 public class RedisConfig {
 
-    @Value("${spring.data.redis.host}")
-    private String host;
-
-    @Value("${spring.data.redis.port}")
-    private int port;
-
-//    @Bean
-//    public ReactiveRedisConnectionFactory reactiveRedisConnectionFactory() {
-//        return new LettuceConnectionFactory(host, port);
-//    }
-
     @Bean
-    public ReactiveRedisOperations<String, Object> redisOperations(ReactiveRedisConnectionFactory factory) {
+    public ReactiveRedisTemplate<String, Object> redisOperations(ReactiveRedisConnectionFactory factory) {
         Jackson2JsonRedisSerializer<Object> serializer = new Jackson2JsonRedisSerializer<>(Object.class);
 
         RedisSerializationContext.RedisSerializationContextBuilder<String, Object> builder =
                 RedisSerializationContext.newSerializationContext(new StringRedisSerializer());
 
-        RedisSerializationContext<String, Object> context = builder.value(serializer).hashValue(serializer)
-                .hashKey(serializer).build();
+        RedisSerializationContext<String, Object> context = builder
+                .value(serializer)
+                .hashValue(serializer)
+                .hashKey(serializer)
+                .build();
 
         return new ReactiveRedisTemplate<>(factory, context);
     }
 
+    @Bean
+    public ReactiveRedisMessageListenerContainer redisMessageListenerContainer(ReactiveRedisConnectionFactory factory) {
+        return new ReactiveRedisMessageListenerContainer(factory);
+    }
+
+    @Bean
+    ApplicationRunner applicationRunner(RedisListener redisListener) {
+        return args -> {
+            List<String> topics = List.of(RedisConst.TEXT_CHANNEL_PREFIX);  // Redis에 퍼블리싱된 채널 중 어떤 걸 감시할 지 설정하는 부분
+            Flux.fromIterable(topics)
+                    .flatMap(redisListener::addTopic)
+                    .thenMany(redisListener.getMessageFlux())
+                    .doOnSubscribe(subscription -> log.info("Redis Listener 작동"))
+                    .doOnError(throwable -> log.error("Redis topic Listener 오류", throwable))
+                    .doFinally(signalType -> log.info("Listener 중지. Signal Type: {}", signalType))
+                    .flatMap(message -> {
+                        String topic = message.getChannel();
+                        String body = message.getMessage();
+                        log.info("[{}] topic으로 받은 메시지: {}", topic, body);
+
+                        return redisListener.handleMessage(topic, body);
+                    })
+                    .subscribe();
+        };
+    }
 }

--- a/src/main/java/com/echo/echo/config/RedisConfig.java
+++ b/src/main/java/com/echo/echo/config/RedisConfig.java
@@ -5,20 +5,17 @@ import com.echo.echo.common.redis.RedisListener;
 import com.echo.echo.domain.user.entity.RefreshToken;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.ApplicationRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.ReactiveRedisConnectionFactory;
 import org.springframework.data.redis.core.ReactiveRedisTemplate;
+import org.springframework.data.redis.listener.ChannelTopic;
 import org.springframework.data.redis.listener.ReactiveRedisMessageListenerContainer;
 import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
 import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.RedisSerializationContext;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 import reactor.core.publisher.Flux;
-
-import java.util.List;
 
 @Slf4j
 @Configuration
@@ -43,28 +40,25 @@ public class RedisConfig {
     }
 
     @Bean
-    public ReactiveRedisMessageListenerContainer redisMessageListenerContainer(ReactiveRedisConnectionFactory factory) {
-        return new ReactiveRedisMessageListenerContainer(factory);
-    }
+    public ReactiveRedisMessageListenerContainer redisMessageListenerContainer(ReactiveRedisConnectionFactory factory, RedisListener redisListener) {
+        ReactiveRedisMessageListenerContainer container = new ReactiveRedisMessageListenerContainer(factory);
+        Flux<ChannelTopic> topics = Flux.fromArray(RedisConst.values())
+                .map(RedisConst::name)
+                .map(ChannelTopic::new);
 
-    @Bean
-    ApplicationRunner applicationRunner(RedisListener redisListener) {
-        return args -> {
-            List<String> topics = List.of(RedisConst.TEXT_CHANNEL_PREFIX);  // Redis에 퍼블리싱된 채널 중 어떤 걸 감시할 지 설정하는 부분
-            Flux.fromIterable(topics)
-                    .flatMap(redisListener::addTopic)
-                    .thenMany(redisListener.getMessageFlux())
-                    .doOnSubscribe(subscription -> log.info("Redis Listener 작동"))
-                    .doOnError(throwable -> log.error("Redis topic Listener 오류", throwable))
-                    .doFinally(signalType -> log.info("Listener 중지. Signal Type: {}", signalType))
-                    .flatMap(message -> {
-                        String topic = message.getChannel();
-                        String body = message.getMessage();
-                        log.info("[{}] topic으로 받은 메시지: {}", topic, body);
+        topics.flatMap(topic -> container.receive(topic)
+                .flatMap(message -> {
+                    RedisConst channel = RedisConst.valueOf(message.getChannel()) ;
+                    String body = message.getMessage();
+                    log.info("[{}] topic으로 받은 메시지: {}", channel, body);
 
-                        return redisListener.handleMessage(topic, body);
-                    })
-                    .subscribe();
-        };
+                    return redisListener.handleMessage(channel, body);
+                }))
+                .doFinally(signalType -> {
+                    container.destroy();
+                })
+                .subscribe();
+
+        return container;
     }
 }

--- a/src/main/java/com/echo/echo/config/WebSocketConfig.java
+++ b/src/main/java/com/echo/echo/config/WebSocketConfig.java
@@ -1,7 +1,11 @@
 package com.echo.echo.config;
 
+import com.echo.echo.common.redis.RedisPublisher;
+import com.echo.echo.common.util.ObjectStringConverter;
+import com.echo.echo.domain.text.TextService;
 import com.echo.echo.domain.text.controller.TextWebSocketHandler;
 import com.echo.echo.domain.video.VideoHandler;
+import com.echo.echo.security.jwt.JwtProvider;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;
@@ -18,11 +22,16 @@ import java.util.Map;
 @RequiredArgsConstructor
 public class WebSocketConfig {
 
-    private final TextWebSocketHandler textHandler;
-    private final VideoHandler videoHandler;
+    @Bean
+    public TextWebSocketHandler textWebSocketHandler(JwtProvider jwtProvider,
+                                                     TextService textService,
+                                                     ObjectStringConverter objectStringConverter,
+                                                     RedisPublisher redisPublisher) {
+        return new TextWebSocketHandler(jwtProvider, textService, objectStringConverter, redisPublisher);
+    }
 
     @Bean
-    public HandlerMapping handlerMapping() {
+    public HandlerMapping handlerMapping(TextWebSocketHandler textHandler, VideoHandler videoHandler) {
         Map<String, WebSocketHandler> map = new HashMap<>();
         map.put("/video/**", videoHandler);
         map.put("/text", textHandler);

--- a/src/main/java/com/echo/echo/domain/text/TextService.java
+++ b/src/main/java/com/echo/echo/domain/text/TextService.java
@@ -22,7 +22,6 @@ public class TextService {
 
     private final TextRepository repository;
     private final Map<Long, Sinks.Many<TextResponse>> channelSinks = new ConcurrentHashMap<>();
-    private final Map<Long, Map<String, WebSocketSession>> channelSessions = new ConcurrentHashMap<>();
 
     public Sinks.Many<TextResponse> getSink(Long channelId) {
         return channelSinks.compute(channelId, (id, existingSink) -> {
@@ -31,10 +30,6 @@ public class TextService {
             }
             return existingSink;
         });
-    }
-
-    public Map<String, WebSocketSession> getSessions(Long channelId) {
-        return channelSessions.computeIfAbsent(channelId, id -> new ConcurrentHashMap<>());
     }
 
     public Mono<TextResponse> sendText(Mono<TextRequest> request, String username, Long userId, Long channelId) {

--- a/src/main/java/com/echo/echo/domain/text/dto/TextResponse.java
+++ b/src/main/java/com/echo/echo/domain/text/dto/TextResponse.java
@@ -1,7 +1,12 @@
 package com.echo.echo.domain.text.dto;
 
 import com.echo.echo.domain.text.entity.Text;
-import lombok.AllArgsConstructor;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -10,7 +15,6 @@ import java.time.LocalDateTime;
 
 @Getter
 @Setter
-@AllArgsConstructor
 @NoArgsConstructor
 public class TextResponse {
 
@@ -18,6 +22,8 @@ public class TextResponse {
     private Long channelId;
     private String contents;
     private String username;
+    @JsonSerialize(using = LocalDateTimeSerializer.class)
+    @JsonDeserialize(using = LocalDateTimeDeserializer.class)
     private LocalDateTime createdAt;
 
     public TextResponse(Text text) {
@@ -26,5 +32,18 @@ public class TextResponse {
         this.channelId = text.getChannelId();
         this.username = text.getUsername();
         this.createdAt = text.getCreatedAt();
+    }
+
+    @JsonCreator
+    public TextResponse(@JsonProperty("id") String id,
+                        @JsonProperty("channelId") Long channelId,
+                        @JsonProperty("contents") String contents,
+                        @JsonProperty("username") String username,
+                        @JsonProperty("createdAt") LocalDateTime createdAt) {
+        this.id = id;
+        this.channelId = channelId;
+        this.contents = contents;
+        this.username = username;
+        this.createdAt = createdAt;
     }
 }

--- a/src/main/java/com/echo/echo/domain/text/repository/TextRepository.java
+++ b/src/main/java/com/echo/echo/domain/text/repository/TextRepository.java
@@ -1,12 +1,9 @@
 package com.echo.echo.domain.text.repository;
 
 import com.echo.echo.domain.text.entity.Text;
-import org.springframework.data.mongodb.repository.Query;
 import org.springframework.data.mongodb.repository.ReactiveMongoRepository;
-import org.springframework.stereotype.Repository;
 import reactor.core.publisher.Flux;
 
-@Repository
 public interface TextRepository extends ReactiveMongoRepository<Text, String> {
 
     Flux<Text> findAllByChannelId(Long channelId);

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -19,5 +19,6 @@ spring.mail.password=${MAIL_PASSWORD}
 
 spring.data.redis.host=${REDIS_HOST}
 spring.data.redis.port=${REDIS_PORT}
+spring.data.redis.uri=${REDIS_URI}
 
 #logging.level.root=debug


### PR DESCRIPTION
### PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
`feat/redis-pub/sub` → `dev`

### 변경 사항
- Redis Pub/Sub 기능 추가
  * data-redis-reactive 라이브러리 내부에 Lettuce가 존재하여 주입하지 않음.
- RedisConfig에서 Bean 등록되던 ReactiveRedisOperations를 ReactiveRedisTemplate로 변경하여 Bean 등록.
  * Redis 기능 확장된 객체로 변경
- TextWebSocketHandler에서 ObjectMapper 메서드 분리하여 ObjectStringConverter 클래스에서 재정의.
- Redis Publisher와 Listener 분리 구현
- RedisConst 클래스를 정의하여 Pub/Sub에 사용되는 Topic을 상수로 정의.
- 차후 Pub/Sub이 필요한 기능은 아래 클래스에서 추가적인 로직이 필요함.
  * RedisConst
  * RedisListener
  * RedisConfig
- Text 도메인에 적용된 Pub/Sub 로직 순서(다중 서버 가동 시 Pub, Sub을 통해 서버 간 동일 메시지 처리 가능)
  * 메시지 전송 → DB 저장 → Redis Pub → Redis Sub → 메시지 수신 → 세션에 메시지 반환

### 테스트 결과
> ### 1. Redis Pub/Sub이 적용된 Text 도메인의 채팅
![스크린샷 2024-08-08 163007](https://github.com/user-attachments/assets/9ea20651-93a1-4bbe-aae1-08f38298d412)
> ### 2. Pub/Sub 서버 콘솔 로그
![스크린샷 2024-08-08 163113](https://github.com/user-attachments/assets/1bbe2d70-346a-4df5-acfe-626b087a4d59)