### PR TITLE
[Feat] Typing Indicators 구현

### DIFF
--- a/src/main/java/com/echo/echo/common/redis/RedisConst.java
+++ b/src/main/java/com/echo/echo/common/redis/RedisConst.java
@@ -5,6 +5,6 @@ import lombok.Getter;
 @Getter
 public enum RedisConst {
 
-    TEXT
-
+    TEXT,
+    TYPING
 }

--- a/src/main/java/com/echo/echo/common/redis/RedisListener.java
+++ b/src/main/java/com/echo/echo/common/redis/RedisListener.java
@@ -18,6 +18,8 @@ public class RedisListener {
         switch (topic) {
             case TEXT:
                 return textWebSocketHandler.sendText(body).then();
+            case TYPING:
+                return textWebSocketHandler.sendTyping(body).then();
             default:
                 return Mono.empty();
         }

--- a/src/main/java/com/echo/echo/domain/text/TextService.java
+++ b/src/main/java/com/echo/echo/domain/text/TextService.java
@@ -2,6 +2,8 @@ package com.echo.echo.domain.text;
 
 import com.echo.echo.domain.text.dto.TextRequest;
 import com.echo.echo.domain.text.dto.TextResponse;
+import com.echo.echo.domain.text.dto.TypingRequest;
+import com.echo.echo.domain.text.dto.TypingResponse;
 import com.echo.echo.domain.text.entity.Text;
 import com.echo.echo.domain.text.repository.TextRepository;
 import lombok.RequiredArgsConstructor;
@@ -30,6 +32,11 @@ public class TextService {
             }
             return existingSink;
         });
+    }
+
+    public Mono<TypingResponse> sendTyping(Mono<TypingRequest> request, String username, Long channelId) {
+        return request
+            .map(req -> new TypingResponse(req, username, channelId));
     }
 
     public Mono<TextResponse> sendText(Mono<TextRequest> request, String username, Long userId, Long channelId) {

--- a/src/main/java/com/echo/echo/domain/text/dto/TypingRequest.java
+++ b/src/main/java/com/echo/echo/domain/text/dto/TypingRequest.java
@@ -1,0 +1,13 @@
+package com.echo.echo.domain.text.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class TypingRequest {
+
+	private boolean typing;
+}

--- a/src/main/java/com/echo/echo/domain/text/dto/TypingResponse.java
+++ b/src/main/java/com/echo/echo/domain/text/dto/TypingResponse.java
@@ -1,0 +1,29 @@
+package com.echo.echo.domain.text.dto;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.Getter;
+
+@Getter
+public class TypingResponse extends TextResponse {
+
+	private Long channelId;
+	private String username;
+	private boolean typing;
+
+	public  TypingResponse(TypingRequest request, String username, Long channelId) {
+		this.channelId = channelId;
+		this.username = username;
+		this.typing = request.isTyping();
+	}
+
+	@JsonCreator
+	public TypingResponse(@JsonProperty("channelId") Long channelId,
+		                  @JsonProperty("username") String username,
+		                  @JsonProperty("typing") boolean typing) {
+		this.channelId = channelId;
+		this.username = username;
+		this.typing = typing;
+	}
+}


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
`feat/typing` -> `dev`

### 변경 사항
Typing Indicators 기능을 구현했습니다.
팀원 @Berithx 님이 구현해주신 Redis Pub/Sub 방식 #67 을 활용하여
다중 서버 환경에서도 일관적으로 작동하도록 구현했습니다.
세부 구현내용은 다음과 같습니다.
- 타이핑 인디케이터 기능 구현
- 여러 사용자의 타이핑 상태 관리
- 공백 시 타이핑 중지 처리

### 테스트 결과
![TypingIndicators](https://github.com/user-attachments/assets/8ef7fc49-372f-43a0-ae71-8922294798bd)
