### PR TITLE
[Feat] S3 업로드/다운로드 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,10 @@ dependencies {
 
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
+    implementation platform('software.amazon.awssdk:bom:2.27.0')
+    implementation 'software.amazon.awssdk:s3'
+    implementation 'software.amazon.awssdk:netty-nio-client'
+
     // WebFlux
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
     implementation 'org.springframework.boot:spring-boot-starter-mail'

--- a/src/main/java/com/echo/echo/common/s3/dto/AWSS3Object.java
+++ b/src/main/java/com/echo/echo/common/s3/dto/AWSS3Object.java
@@ -1,0 +1,16 @@
+package com.echo.echo.common.s3.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.Instant;
+
+@Getter
+@AllArgsConstructor
+public class AWSS3Object {
+
+    String key;
+    Instant lastModified;
+    String eTag;
+    Long size;
+}

--- a/src/main/java/com/echo/echo/common/s3/dto/FileResponse.java
+++ b/src/main/java/com/echo/echo/common/s3/dto/FileResponse.java
@@ -1,0 +1,13 @@
+package com.echo.echo.common.s3.dto;
+
+import lombok.Getter;
+
+@Getter
+public class FileResponse {
+
+    String name;
+    String uploadId;
+    String path;
+    String type;
+    String eTag;
+}

--- a/src/main/java/com/echo/echo/common/s3/dto/SuccessResponse.java
+++ b/src/main/java/com/echo/echo/common/s3/dto/SuccessResponse.java
@@ -1,0 +1,12 @@
+package com.echo.echo.common.s3.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class SuccessResponse {
+
+    Object data;
+    String message;
+}

--- a/src/main/java/com/echo/echo/common/s3/dto/UploadStatus.java
+++ b/src/main/java/com/echo/echo/common/s3/dto/UploadStatus.java
@@ -1,0 +1,36 @@
+package com.echo.echo.common.s3.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+import software.amazon.awssdk.services.s3.model.CompletedPart;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Getter
+public class UploadStatus {
+
+    private final String fileKey;
+    private final String contentType;
+    @Setter
+    private String uploadId;
+    private int partCounter;
+    @Setter
+    private int buffered;
+
+    private final Map<Integer, CompletedPart> completedParts = new HashMap<>();
+
+    public UploadStatus(String contentType, String fileKey) {
+        this.contentType = contentType;
+        this.fileKey = fileKey;
+        this.buffered = 0;
+    }
+
+    public void addBuffered(int buffered) {
+        this.buffered += buffered;
+    }
+
+    public int getAddedPartCounter() {
+        return ++this.partCounter;
+    }
+}

--- a/src/main/java/com/echo/echo/common/s3/error/S3ErrorCode.java
+++ b/src/main/java/com/echo/echo/common/s3/error/S3ErrorCode.java
@@ -1,0 +1,31 @@
+package com.echo.echo.common.s3.error;
+
+import com.echo.echo.common.exception.BaseCode;
+import com.echo.echo.common.exception.CommonReason;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum S3ErrorCode implements BaseCode {
+    FILE_UPLOAD_FAIL(HttpStatus.BAD_REQUEST, 90,"파일 업로드에 실패했습니다.", "파일 업로드에 실패했습니다."),
+    FILE_TYPE_INVALID(HttpStatus.BAD_REQUEST, 91, "업로드할 수 있는 파일 확장자가 아닙니다.", "업드할 수 있는 파일 확장자가 아닙니다."),
+    FILE_IS_NULL(HttpStatus.BAD_REQUEST, 92, "파일이 유효하지 않습니다.", "파일이 유효하지 않습니다."),
+    FILE_SIZE_OVER(HttpStatus.BAD_REQUEST, 93, "파일의 용량이 허용크기를 초과했습니다.", "파일의 용량이 허용크기를 초과했습니다."),
+    ;
+
+    private final HttpStatus httpStatus;
+    private final int code;
+    private final String msg;
+    private final String remark;
+
+    @Override
+    public CommonReason getCommonReason() {
+        return CommonReason.builder()
+                .status(httpStatus)
+                .code(code)
+                .msg(msg)
+                .build();
+    }
+}

--- a/src/main/java/com/echo/echo/common/s3/service/S3Service.java
+++ b/src/main/java/com/echo/echo/common/s3/service/S3Service.java
@@ -1,0 +1,173 @@
+package com.echo.echo.common.s3.service;
+
+import com.echo.echo.common.s3.dto.AWSS3Object;
+import com.echo.echo.common.s3.dto.UploadStatus;
+import com.echo.echo.common.s3.util.FileUtils;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.http.codec.multipart.FilePart;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import software.amazon.awssdk.core.BytesWrapper;
+import software.amazon.awssdk.core.async.AsyncRequestBody;
+import software.amazon.awssdk.core.async.AsyncResponseTransformer;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.model.*;
+
+import java.nio.ByteBuffer;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class S3Service {
+
+    private final S3AsyncClient s3Client;
+    @Value("${aws.s3.bucket.name}")
+    private String bucketName;
+    @Value("${aws.s3.upload.part.min.size}")
+    private Long uploadPartMinSize;
+    @Value("${aws.s3.upload.max.size}")
+    private Long uploadMaxSize;
+
+    public Mono<Void> deleteObject(String objectKey) {
+        log.info("Delete Object with key: {}", objectKey);
+        return Mono.just(DeleteObjectRequest.builder()
+                        .bucket(bucketName)
+                        .key(objectKey)
+                        .build())
+                .map(s3Client::deleteObject)
+                .flatMap(Mono::fromFuture)
+                .then();
+    }
+
+    public Flux<AWSS3Object> getObjects() {
+        log.info("Listing objects in S3 bucket: {}", bucketName);
+        return Flux.from(s3Client.listObjectsV2Paginator(ListObjectsV2Request.builder()
+                        .bucket(bucketName)
+                        .build()))
+                .flatMap(response -> Flux.fromIterable(response.contents()))
+                .map(s3Object -> new AWSS3Object(s3Object.key(), s3Object.lastModified(),s3Object.eTag(), s3Object.size()));
+    }
+
+    public Mono<byte[]> getByteObject(String key) {
+        log.debug("Fetching object as byte array from S3 bucket: {}, key: {}", bucketName, key);
+        return Mono.just(GetObjectRequest.builder()
+                        .bucket(bucketName)
+                        .key(key)
+                        .build())
+                .map(it -> s3Client.getObject(it, AsyncResponseTransformer.toBytes()))
+                .flatMap(Mono::fromFuture)
+                .map(BytesWrapper::asByteArray);
+    }
+
+    public Mono<String> upload(FilePart filePart) {
+
+        return FileUtils.checkFileSize(filePart, uploadMaxSize)
+                .then(Mono.defer(() -> {
+                    // 파일 확장자 획득
+                    String extension = StringUtils.getFilenameExtension(filePart.filename());
+                    // 업로드 파일 이름 획득
+                    String filename = String.format("%s-%s.%s", System.currentTimeMillis(), UUID.randomUUID(), extension);
+                    // 메타 데이터 설정 : 파일 이름을 사용한 Key : Value
+                    Map<String, String> metadata = Map.of("filename", filename);
+                    // get media type
+                    MediaType mediaType = Objects.requireNonNullElse(filePart.headers().getContentType(), MediaType.APPLICATION_OCTET_STREAM);
+
+                    // S3에 멀티파트 업로드를 시작하는 비동기 요청 생성
+                    CompletableFuture<CreateMultipartUploadResponse> s3AsyncClientMultipartUpload = s3Client
+                            .createMultipartUpload(CreateMultipartUploadRequest.builder()
+                                    .contentType(mediaType.toString())
+                                    .key(filename)
+                                    .metadata(metadata)
+                                    .bucket(bucketName)
+                                    .build());
+
+                    // 업로드 상태 추적 객체 생성
+                    UploadStatus uploadStatus = new UploadStatus(Objects.requireNonNull(filePart.headers().getContentType()).toString(), filename);
+
+                    // S3 멀티파트 업로드 요청 결과 처리
+                    return Mono.fromFuture(s3AsyncClientMultipartUpload)
+                            .flatMapMany(response -> {
+                                // 49번째 줄의 요청의 결과를 확인하고 업로드 ID 설정
+                                FileUtils.checkSdkResponse(response);
+                                uploadStatus.setUploadId(response.uploadId());
+                                // 파일의 내용을 Flux<DataBuffer>로 파일을 스트림 처리하여 반환
+                                return filePart.content();
+                            })
+                            // 파일 내용을 버퍼링하면서, 특정 크기 이상이 되면 나누어 처리
+                            .bufferUntil(dataBuffer -> {
+                                // 버퍼된 데이터의 크리글 업로드 상태에 추가
+                                uploadStatus.addBuffered(dataBuffer.readableByteCount());
+                                // 버퍼된 데이터가 멀티파트 최소 크기 이상이면 true 반환(버퍼 플러시)
+                                if (uploadStatus.getBuffered() >= uploadPartMinSize) {
+                                    // 버퍼 초기화
+                                    uploadStatus.setBuffered(0);
+                                    return true;
+                                }
+                                return false;
+                            })
+                            // DataBuffer를 ByteBuffer로 변환
+                            .map(FileUtils::dataBufferToByteBuffer)
+                            // 변환된 ByteBuffer를 사용하여 S3에 멀티파트 업로드의 일부를 업로드
+                            .flatMap(byteBuffer -> uploadPartObject(uploadStatus, byteBuffer))
+                            // 백프레셔를 처리하기 위해 버퍼 사용
+                            .onBackpressureBuffer()
+                            // 업로드가 완료된 부분들을 업로드 상태에 추가
+                            .reduce(uploadStatus, (status, completedPart) -> {
+                                (status).getCompletedParts().put(completedPart.partNumber(), completedPart);
+                                return status;
+                            })
+                            // 모든 파트가 업로드 되면 멀티파트 업로드를 완료
+                            .flatMap(uploadStatus1 -> completeUpload(uploadStatus))
+                            // 업로드 완료 후 응답 데이터 생성 후 반환
+                            .map(response -> {
+                                FileUtils.checkSdkResponse(response);
+                                return response.location();
+                            });
+                }));
+    }
+
+    private Mono<CompletedPart> uploadPartObject(UploadStatus uploadStatus, ByteBuffer buffer) {
+        final int partNumber = uploadStatus.getAddedPartCounter();
+
+        CompletableFuture<UploadPartResponse> uploadPartResponseCompletableFuture = s3Client.uploadPart(UploadPartRequest.builder()
+                        .bucket(bucketName)
+                        .key(uploadStatus.getFileKey())
+                        .partNumber(partNumber)
+                        .uploadId(uploadStatus.getUploadId())
+                        .contentLength((long) buffer.capacity())
+                        .build(),
+                AsyncRequestBody.fromPublisher(Mono.just(buffer)));
+
+        return Mono
+                .fromFuture(uploadPartResponseCompletableFuture)
+                .map(uploadPartResult -> {
+                    FileUtils.checkSdkResponse(uploadPartResult);
+                    return CompletedPart.builder()
+                            .eTag(uploadPartResult.eTag())
+                            .partNumber(partNumber)
+                            .build();
+                });
+    }
+
+    private Mono<CompleteMultipartUploadResponse> completeUpload(UploadStatus uploadStatus) {
+        CompletedMultipartUpload multipartUpload = CompletedMultipartUpload.builder()
+                .parts(uploadStatus.getCompletedParts().values())
+                .build();
+
+        return Mono.fromFuture(s3Client.completeMultipartUpload(CompleteMultipartUploadRequest.builder()
+                .bucket(bucketName)
+                .uploadId(uploadStatus.getUploadId())
+                .multipartUpload(multipartUpload)
+                .key(uploadStatus.getFileKey())
+                .build()));
+    }
+}

--- a/src/main/java/com/echo/echo/common/s3/util/FileUtils.java
+++ b/src/main/java/com/echo/echo/common/s3/util/FileUtils.java
@@ -1,0 +1,101 @@
+package com.echo.echo.common.s3.util;
+
+import com.echo.echo.common.exception.CustomException;
+import com.echo.echo.common.s3.error.S3ErrorCode;
+import lombok.experimental.UtilityClass;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.io.buffer.DataBuffer;
+import org.springframework.core.io.buffer.DataBufferUtils;
+import org.springframework.http.codec.multipart.FilePart;
+import org.springframework.util.ObjectUtils;
+import reactor.core.publisher.Mono;
+import software.amazon.awssdk.core.SdkResponse;
+
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+
+@Slf4j
+@UtilityClass
+public class FileUtils {
+
+    private final String[] contentTypes = {
+            "image/png",
+            "image/jpg",
+            "image/jpeg",
+            "image/bmp",
+            "image/gif",
+            "image/ief",
+            "image/pipeg",
+            "image/svg+xml",
+            "image/tiff",
+            "image/webp",
+            "image/ico"
+    };
+
+    private boolean isValidType(final FilePart filePart) {
+        log.info(String.valueOf(filePart.headers().getContentType()));
+        return isSupportedContentType(Objects.requireNonNull(filePart.headers().getContentType()).toString());
+    }
+
+    private boolean isEmpty(final FilePart filePart) {
+        return ObjectUtils.isEmpty(filePart.filename())
+                && ObjectUtils.isEmpty(filePart.headers().getContentType());
+    }
+
+    private boolean isSupportedContentType(final String contentType) {
+        return Arrays.asList(contentTypes).contains(contentType);
+    }
+
+    public ByteBuffer dataBufferToByteBuffer(List<DataBuffer> buffers) {
+        log.info("Creating ByteBuffer from {} chunks", buffers.size());
+
+        int partSize = 0;
+        for(DataBuffer b : buffers) {
+            partSize += b.readableByteCount();
+        }
+
+        ByteBuffer partData = ByteBuffer.allocate(partSize);
+        buffers.forEach(buffer -> {
+            byte[] bytes = new byte[buffer.readableByteCount()];
+            buffer.read(bytes);
+            partData.put(bytes);
+        });
+        partData.rewind();
+
+        log.info("PartData: capacity={}", partData.capacity());
+        return partData;
+    }
+
+    public void checkSdkResponse(SdkResponse sdkResponse) {
+        if (sdkResponse.sdkHttpResponse() == null || !sdkResponse.sdkHttpResponse().isSuccessful()) {
+            throw new CustomException(S3ErrorCode.FILE_UPLOAD_FAIL);
+        }
+    }
+
+    public void filePartValidator(FilePart filePart) {
+        if (isEmpty(filePart)){
+            throw new CustomException(S3ErrorCode.FILE_IS_NULL);
+        }
+        if (!isValidType(filePart)){
+            throw new CustomException(S3ErrorCode.FILE_TYPE_INVALID);
+        }
+    }
+
+    public Mono<Void> checkFileSize(FilePart filePart, Long maxFileSize) {
+        return filePart.content()
+                .map(dataBuffer -> {
+                    long size = dataBuffer.readableByteCount();
+                    DataBufferUtils.release(dataBuffer);
+                    return size;
+                })
+                .reduce(Long::sum)
+                .flatMap(totalSize -> {
+                    if (totalSize > maxFileSize) {
+                        return Mono.error(new CustomException(S3ErrorCode.FILE_SIZE_OVER));
+                    }
+                    return Mono.empty();
+                });
+    }
+}

--- a/src/main/java/com/echo/echo/config/S3Config.java
+++ b/src/main/java/com/echo/echo/config/S3Config.java
@@ -1,0 +1,54 @@
+package com.echo.echo.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.*;
+import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
+import software.amazon.awssdk.http.nio.netty.NettyNioAsyncHttpClient;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.S3AsyncClientBuilder;
+import software.amazon.awssdk.services.s3.S3Configuration;
+
+import java.net.URI;
+import java.time.Duration;
+
+@Configuration
+public class S3Config {
+
+    @Value("${aws.credentials.accessKey}")
+    private String accessKey;
+    @Value("${aws.credentials.secretKey}")
+    private String secretKey;
+    @Value("${aws.s3.region}")
+    private Region region;
+
+    @Bean
+    public S3AsyncClient s3Client(AwsCredentialsProvider credentialsProvider) {
+        SdkAsyncHttpClient httpClient = NettyNioAsyncHttpClient.builder()
+                .writeTimeout(Duration.ZERO)
+                .maxConcurrency(64)
+                .build();
+
+        S3Configuration s3Configuration = S3Configuration.builder()
+                .checksumValidationEnabled(false)
+                .chunkedEncodingEnabled(true)
+                .build();
+
+        S3AsyncClientBuilder builder = S3AsyncClient.builder()
+                .httpClient(httpClient)
+                .region(region)
+                .credentialsProvider(credentialsProvider)
+                .forcePathStyle(true)
+                .serviceConfiguration(s3Configuration);
+
+        return builder.build();
+    }
+
+    @Bean
+    public AwsCredentialsProvider awsCredentialsProvider() {
+        return () -> AwsBasicCredentials.create(accessKey, secretKey);
+    }
+}

--- a/src/main/java/com/echo/echo/config/WebFluxConfig.java
+++ b/src/main/java/com/echo/echo/config/WebFluxConfig.java
@@ -1,12 +1,29 @@
 package com.echo.echo.config;
 
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.EnableAspectJAutoProxy;
+import org.springframework.http.codec.ServerCodecConfigurer;
+import org.springframework.http.codec.multipart.DefaultPartHttpMessageReader;
+import org.springframework.http.codec.multipart.MultipartHttpMessageReader;
 import org.springframework.web.reactive.config.EnableWebFlux;
+import org.springframework.web.reactive.config.WebFluxConfigurer;
 
 @Configuration
 @EnableWebFlux
-@EnableAspectJAutoProxy
-public class WebFluxConfig {
+public class WebFluxConfig implements WebFluxConfigurer {
 
+    @Override
+    public void configureHttpMessageCodecs(ServerCodecConfigurer configurer) {
+
+        var partReader = new DefaultPartHttpMessageReader();
+        partReader.setMaxParts(4);
+
+        partReader.setMaxDiskUsagePerPart(5L * 1024L * 1024L); // 업로드 파트 당 허용크기, 현재 5MB로 설정
+        partReader.setEnableLoggingRequestDetails(true);
+        MultipartHttpMessageReader multipartReader = new
+                MultipartHttpMessageReader(partReader);
+        multipartReader.setEnableLoggingRequestDetails(true);
+        configurer.defaultCodecs().multipartReader(multipartReader);
+
+        configurer.defaultCodecs().maxInMemorySize(512 * 1024);
+    }
 }

--- a/src/main/java/com/echo/echo/domain/TextFacade.java
+++ b/src/main/java/com/echo/echo/domain/TextFacade.java
@@ -1,0 +1,42 @@
+package com.echo.echo.domain;
+
+import com.echo.echo.common.redis.RedisConst;
+import com.echo.echo.common.redis.RedisPublisher;
+import com.echo.echo.common.s3.service.S3Service;
+import com.echo.echo.common.s3.util.FileUtils;
+import com.echo.echo.domain.text.TextService;
+import com.echo.echo.domain.text.dto.TextRequest;
+import com.echo.echo.domain.text.entity.Text;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.listener.ChannelTopic;
+import org.springframework.http.codec.multipart.FilePart;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+
+@Component
+@RequiredArgsConstructor
+public class TextFacade {
+
+    private final TextService textService;
+    private final S3Service s3Service;
+    private final RedisPublisher redisPublisher;
+
+    public Mono<Void> textChatFileUpload(Mono<FilePart> filePart, Long userId, String username, Long channelId) {
+        return filePart.flatMap(part -> {
+            FileUtils.filePartValidator(part);
+
+            Mono<String> uploadUrl = s3Service.upload(part);
+
+            return uploadUrl.flatMap(url -> {
+                    Mono<TextRequest> request = Mono.just(new TextRequest(url));
+
+                        return request
+                                .flatMap(req -> textService.sendText(request, username, userId, channelId, Text.TextType.FILE))
+                                .flatMap(response -> {
+                                    ChannelTopic topic = new ChannelTopic(RedisConst.TEXT.name());
+                                    return redisPublisher.publish(topic, response);
+                                });
+                    });
+        });
+    }
+}

--- a/src/main/java/com/echo/echo/domain/text/TextService.java
+++ b/src/main/java/com/echo/echo/domain/text/TextService.java
@@ -9,7 +9,6 @@ import com.echo.echo.domain.text.repository.TextRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-import org.springframework.web.reactive.socket.WebSocketSession;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.core.publisher.Sinks;
@@ -39,9 +38,9 @@ public class TextService {
             .map(req -> new TypingResponse(req, username, channelId));
     }
 
-    public Mono<TextResponse> sendText(Mono<TextRequest> request, String username, Long userId, Long channelId) {
+    public Mono<TextResponse> sendText(Mono<TextRequest> request, String username, Long userId, Long channelId, Text.TextType type) {
         return request
-                .map(textRequest -> new Text(textRequest, username, userId, channelId))
+                .map(textRequest -> new Text(textRequest.getContents(), username, userId, channelId, type))
                 .flatMap(repository::save)
                 .map(TextResponse::new);
     }

--- a/src/main/java/com/echo/echo/domain/text/controller/TextController.java
+++ b/src/main/java/com/echo/echo/domain/text/controller/TextController.java
@@ -1,15 +1,27 @@
 package com.echo.echo.domain.text.controller;
 
-import com.echo.echo.domain.text.TextService;
+import com.echo.echo.domain.TextFacade;
+import com.echo.echo.security.principal.UserPrincipal;
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.http.codec.multipart.FilePart;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import reactor.core.publisher.Mono;
 
-@Controller
+@RestController
 @RequiredArgsConstructor
 @RequestMapping("text")
 public class TextController {
 
-    private final TextService textService;
+    private final TextFacade textFacade;
+
+    @PostMapping("/{channelId}/file")
+    public Mono<Void> textChatFileUpload(@PathVariable("channelId") Long channelId,
+                                         @RequestPart("file-data") FilePart filePart,
+                                         @AuthenticationPrincipal UserPrincipal userPrincipal) {
+        Long userId = userPrincipal.getUser().getId();
+        String username = userPrincipal.getUser().getNickname();
+        return textFacade.textChatFileUpload(Mono.just(filePart), userId, username, channelId);
+    }
 
 }

--- a/src/main/java/com/echo/echo/domain/text/controller/TextWebSocketHandler.java
+++ b/src/main/java/com/echo/echo/domain/text/controller/TextWebSocketHandler.java
@@ -16,6 +16,7 @@ import com.echo.echo.domain.text.dto.TextRequest;
 import com.echo.echo.domain.text.dto.TextResponse;
 import com.echo.echo.domain.text.dto.TypingRequest;
 import com.echo.echo.domain.text.dto.TypingResponse;
+import com.echo.echo.domain.text.entity.Text;
 import com.echo.echo.security.jwt.JwtProvider;
 
 import lombok.RequiredArgsConstructor;
@@ -64,7 +65,7 @@ public class TextWebSocketHandler implements WebSocketHandler {
                             });
                     } else {
                         Mono<TextRequest> request = objectStringConverter.stringToObject(payload, TextRequest.class);
-                        return textService.sendText(request, username, userId, channelId)
+                        return textService.sendText(request, username, userId, channelId, Text.TextType.TEXT)
                             .flatMap(response -> {
                                 ChannelTopic topic = new ChannelTopic(RedisConst.TEXT.name());
                                 return redisPublisher.publish(topic, response);

--- a/src/main/java/com/echo/echo/domain/text/dto/TextResponse.java
+++ b/src/main/java/com/echo/echo/domain/text/dto/TextResponse.java
@@ -3,6 +3,7 @@ package com.echo.echo.domain.text.dto;
 import com.echo.echo.domain.text.entity.Text;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
@@ -20,6 +21,7 @@ public class TextResponse {
 
     private String id;
     private Long channelId;
+    private Text.TextType type;
     private String contents;
     private String username;
     @JsonSerialize(using = LocalDateTimeSerializer.class)
@@ -28,6 +30,7 @@ public class TextResponse {
 
     public TextResponse(Text text) {
         this.id = text.getId();
+        this.type = text.getType();
         this.contents = text.getContents();
         this.channelId = text.getChannelId();
         this.username = text.getUsername();
@@ -37,11 +40,13 @@ public class TextResponse {
     @JsonCreator
     public TextResponse(@JsonProperty("id") String id,
                         @JsonProperty("channelId") Long channelId,
+                        @JsonProperty("type") Text.TextType type,
                         @JsonProperty("contents") String contents,
                         @JsonProperty("username") String username,
                         @JsonProperty("createdAt") LocalDateTime createdAt) {
         this.id = id;
         this.channelId = channelId;
+        this.type = type;
         this.contents = contents;
         this.username = username;
         this.createdAt = createdAt;

--- a/src/main/java/com/echo/echo/domain/text/entity/Text.java
+++ b/src/main/java/com/echo/echo/domain/text/entity/Text.java
@@ -1,6 +1,5 @@
 package com.echo.echo.domain.text.entity;
 
-import com.echo.echo.domain.text.dto.TextRequest;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -15,17 +14,24 @@ import java.time.LocalDateTime;
 public class Text {
     @Id
     private String id;
+    private TextType type;
     private String contents;
     private String username;
     private Long channelId;
     private Long userId;
     private LocalDateTime createdAt;
 
-    public Text(TextRequest request, String username, Long userId, Long channelId) {
-        this.contents = request.getContents();
+    public Text(String contents, String username, Long userId, Long channelId, TextType type) {
+        this.contents = contents;
         this.channelId = channelId;
         this.username = username;
         this.userId = userId;
+        this.type = type;
         this.createdAt = LocalDateTime.now();
+    }
+
+    public enum TextType {
+        TEXT,
+        FILE
     }
 }

--- a/src/main/java/com/echo/echo/security/jwt/JwtProvider.java
+++ b/src/main/java/com/echo/echo/security/jwt/JwtProvider.java
@@ -99,6 +99,7 @@ public class JwtProvider {
         User user = User.builder()
                 .id(Long.valueOf((Integer) claims.get(ID_KEY)))
                 .email(claims.getSubject())
+                .nickname((String) claims.get(NICKNAME_KEY))
                 .build();
 
         return new UsernamePasswordAuthenticationToken(new UserPrincipal(user), null, authorities);

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -21,6 +21,14 @@ spring.data.redis.host=${REDIS_HOST}
 spring.data.redis.port=${REDIS_PORT}
 spring.data.redis.uri=${REDIS_URI}
 
+aws.credentials.accessKey=${AWS_CREDENTIALS_ACCESSKEY}
+aws.credentials.secretKey=${AWS_CREDENTIALS_SECRETKEY}
+aws.s3.bucket.name=${AWS_S3_BUCKET_NAME}
+aws.s3.region=ap-northeast-2
+aws.s3.upload.part.min.size=5242880
+aws.s3.upload.max.size=20971520
+#aws.s3.endpoint=http://localhost:4566/
+
 #logging.level.root=debug
 
 kakao.client-id=${KAKAO_CLIENT_ID}


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
feat/S3 -> dev

### 변경 사항
- AWS S3 업로드/다운로드 구현
- S3는 공용기능으로 각 도메인에서 호출할 수 있도록 구현
- 저장, 삭제, 조회 메서드 구현 후 필요한 도메인에서 호출하여 사용
- 적용예제는 TextController 참조

### 테스트 결과
> ### 1. S3 업로드 테스트 영상
[![S3 Upload](https://github.com/user-attachments/assets/6332126b-09a6-47c1-9264-1db1ebbc0d73)](https://youtu.be/kyPVtDwJjpI)
> ### 2. 업로드 결과 (서버 콘솔)
![스크린샷 2024-08-14 010620](https://github.com/user-attachments/assets/e14b2643-f396-44a5-83b9-8bd541717640)
![스크린샷 2024-08-14 010634](https://github.com/user-attachments/assets/68540727-c72f-4e68-9e1f-5dffc1213ba0)
> ### 3. 업로드 결과 (S3)
![스크린샷 2024-08-14 010510](https://github.com/user-attachments/assets/d0e7dd94-c408-409e-9c86-984229580f7f)