### PR TITLE
[Fix] jwt 만료 시 500 에러 반환 이슈 수정 [#78]

### DIFF
--- a/src/main/java/com/echo/echo/domain/auth/error/AuthErrorCode.java
+++ b/src/main/java/com/echo/echo/domain/auth/error/AuthErrorCode.java
@@ -9,8 +9,8 @@ import org.springframework.http.HttpStatus;
 @Getter
 @AllArgsConstructor
 public enum AuthErrorCode implements BaseCode {
-    PASSWORD_NOT_MATCH(HttpStatus.FORBIDDEN, 50,"비밀번호가 일치하지 않습니다.", "비밀번호가 일치하지 않습니다."),
-    NOT_ACTIVATED_ACCOUNT(HttpStatus.UNAUTHORIZED, 51, "메일 인증이 안된 계정입니다. 메일 인증 완료 후 다시 시도해주세요.", "계정 활성화가 필요합니다."),
+    PASSWORD_NOT_MATCH(HttpStatus.BAD_REQUEST, 50,"비밀번호가 일치하지 않습니다.", "비밀번호가 일치하지 않습니다."),
+    NOT_ACTIVATED_ACCOUNT(HttpStatus.BAD_REQUEST, 51, "메일 인증이 안된 계정입니다. 메일 인증 완료 후 다시 시도해주세요.", "계정 활성화가 필요합니다."),
     NOT_FOUND_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, 52,"자격증명에 실패하였습니다.", "해당하는 리프레시 토큰을 찾을 수 없습니다."),
     ;
 

--- a/src/main/java/com/echo/echo/security/config/SecurityConfig.java
+++ b/src/main/java/com/echo/echo/security/config/SecurityConfig.java
@@ -1,5 +1,7 @@
 package com.echo.echo.security.config;
 
+import com.echo.echo.common.exception.CustomException;
+import com.echo.echo.common.exception.codes.CommonErrorCode;
 import com.echo.echo.security.jwt.JwtProvider;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -85,7 +87,8 @@ public class SecurityConfig {
     private ServerAuthenticationConverter serverAuthenticationConverter() {
         return exchange -> jwtProvider.resolveToken(exchange.getRequest())
                 .filter(jwtProvider::isValidToken)
-                .flatMap(token -> Mono.justOrEmpty(jwtProvider.getAuthentication(token)));
+                .flatMap(token -> Mono.justOrEmpty(jwtProvider.getAuthentication(token)))
+                .onErrorResume(err -> Mono.error(new CustomException(CommonErrorCode.UNAUTHORIZED)));
     }
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 버그 수정

### 반영 브랜치
fix/jwt-error

### 변경 사항
- #78 에서 JWT 만료 시 500에러가 리턴되어 프론트에서 세션 만료 처리를 못하는 이슈가 발생했기에 jwt검증 시 예외 반환이 되면 401에러가 리턴되도록 수정
- 401, 403에러는 토큰관련 에러이므로 그 이외 에러들은 401, 403을 갖지 않도록 수정

### 테스트 결과
수정 이후 만료될 시 401에러 반환
![image](https://github.com/user-attachments/assets/cd121236-b8e2-4a08-af73-9d800529c050)