### PR TITLE
[Fix] 텍스트 관련 기능 리팩토링

### DIFF
--- a/src/main/java/com/echo/echo/common/s3/error/S3ErrorCode.java
+++ b/src/main/java/com/echo/echo/common/s3/error/S3ErrorCode.java
@@ -14,6 +14,7 @@ public enum S3ErrorCode implements BaseCode {
     FILE_TYPE_INVALID(HttpStatus.BAD_REQUEST, 91, "업로드할 수 있는 파일 확장자가 아닙니다.", "업드할 수 있는 파일 확장자가 아닙니다."),
     FILE_IS_NULL(HttpStatus.BAD_REQUEST, 92, "파일이 유효하지 않습니다.", "파일이 유효하지 않습니다."),
     FILE_SIZE_OVER(HttpStatus.BAD_REQUEST, 93, "파일의 용량이 허용크기를 초과했습니다.", "파일의 용량이 허용크기를 초과했습니다."),
+    S3_URL_INVALID(HttpStatus.NOT_FOUND, 94, "파일의 저장경로 변환 간 오류가 발생했습니다.", "파일의 저장경로 변환 간 오류가 발생했습니다.")
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/echo/echo/common/s3/service/S3Service.java
+++ b/src/main/java/com/echo/echo/common/s3/service/S3Service.java
@@ -37,8 +37,8 @@ public class S3Service {
     @Value("${aws.s3.upload.max.size}")
     private Long uploadMaxSize;
 
-    public Mono<Void> deleteObject(String objectKey) {
-        log.debug("Delete Object with key: {}", objectKey);
+    public Mono<Void> deleteObject(String objectKeyUri) {
+        String objectKey = FileUtils.extractKeyFromUrl(objectKeyUri);
         return Mono.just(DeleteObjectRequest.builder()
                         .bucket(bucketName)
                         .key(objectKey)
@@ -49,7 +49,6 @@ public class S3Service {
     }
 
     public Flux<AWSS3Object> getObjects() {
-        log.debug("Listing objects in S3 bucket: {}", bucketName);
         return Flux.from(s3Client.listObjectsV2Paginator(ListObjectsV2Request.builder()
                         .bucket(bucketName)
                         .build()))
@@ -57,11 +56,11 @@ public class S3Service {
                 .map(s3Object -> new AWSS3Object(s3Object.key(), s3Object.lastModified(),s3Object.eTag(), s3Object.size()));
     }
 
-    public Mono<byte[]> getByteObject(String key) {
-        log.debug("Fetching object as byte array from S3 bucket: {}, key: {}", bucketName, key);
+    public Mono<byte[]> getByteObject(String objectKeyUri) {
+        String objectKey = FileUtils.extractKeyFromUrl(objectKeyUri);
         return Mono.just(GetObjectRequest.builder()
                         .bucket(bucketName)
-                        .key(key)
+                        .key(objectKey)
                         .build())
                 .map(it -> s3Client.getObject(it, AsyncResponseTransformer.toBytes()))
                 .flatMap(Mono::fromFuture)

--- a/src/main/java/com/echo/echo/common/s3/util/FileUtils.java
+++ b/src/main/java/com/echo/echo/common/s3/util/FileUtils.java
@@ -2,6 +2,7 @@ package com.echo.echo.common.s3.util;
 
 import com.echo.echo.common.exception.CustomException;
 import com.echo.echo.common.s3.error.S3ErrorCode;
+import io.jsonwebtoken.MalformedJwtException;
 import lombok.experimental.UtilityClass;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.io.buffer.DataBuffer;
@@ -11,6 +12,7 @@ import org.springframework.util.ObjectUtils;
 import reactor.core.publisher.Mono;
 import software.amazon.awssdk.core.SdkResponse;
 
+import java.net.URI;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.List;
@@ -97,6 +99,18 @@ public class FileUtils {
                     }
                     return Mono.empty();
                 });
+    }
+
+    public String extractKeyFromUrl(String s3Url) {
+        try {
+            URI uri = URI.create(s3Url);
+            String path = uri.getPath();
+            String key = path.substring(1);
+            log.info("S3 Object Key : {}", key);
+            return key;
+        } catch (MalformedJwtException e) {
+            throw new CustomException(S3ErrorCode.S3_URL_INVALID);
+        }
     }
 
 }

--- a/src/main/java/com/echo/echo/common/util/ObjectStringConverter.java
+++ b/src/main/java/com/echo/echo/common/util/ObjectStringConverter.java
@@ -4,13 +4,14 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.stereotype.Component;
 import reactor.core.publisher.Mono;
 
 import java.util.Map;
 
 @Slf4j
 @RequiredArgsConstructor
-@Configuration(proxyBeanMethods = false)
+@Component
 public class ObjectStringConverter {
 
     private final ObjectMapper mapper;

--- a/src/main/java/com/echo/echo/config/WebFluxConfig.java
+++ b/src/main/java/com/echo/echo/config/WebFluxConfig.java
@@ -17,10 +17,9 @@ public class WebFluxConfig implements WebFluxConfigurer {
         var partReader = new DefaultPartHttpMessageReader();
         partReader.setMaxParts(4);
 
-        partReader.setMaxDiskUsagePerPart(5L * 1024L * 1024L); // 업로드 파트 당 허용크기, 현재 5MB로 설정
+        partReader.setMaxDiskUsagePerPart(20L * 1024L * 1024L); // 최대 업로드 허용크기, 현재 20MB로 설정
         partReader.setEnableLoggingRequestDetails(true);
-        MultipartHttpMessageReader multipartReader = new
-                MultipartHttpMessageReader(partReader);
+        MultipartHttpMessageReader multipartReader = new MultipartHttpMessageReader(partReader);
         multipartReader.setEnableLoggingRequestDetails(true);
         configurer.defaultCodecs().multipartReader(multipartReader);
 

--- a/src/main/java/com/echo/echo/domain/channel/ChannelFacade.java
+++ b/src/main/java/com/echo/echo/domain/channel/ChannelFacade.java
@@ -1,11 +1,14 @@
 package com.echo.echo.domain.channel;
 
+import com.echo.echo.common.s3.service.S3Service;
 import com.echo.echo.domain.channel.dto.ChannelRequestDto;
 import com.echo.echo.domain.channel.dto.ChannelResponseDto;
 import com.echo.echo.domain.notification.NotificationService;
 import com.echo.echo.domain.notification.entity.Notification;
 import com.echo.echo.domain.space.SpaceService;
 import com.echo.echo.domain.space.dto.SpaceMemberDto;
+import com.echo.echo.domain.text.TextService;
+import com.echo.echo.domain.text.entity.Text;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import reactor.core.publisher.Flux;
@@ -22,6 +25,8 @@ public class ChannelFacade {
     private final ChannelService channelService;
     private final SpaceService spaceService;
     private final NotificationService notificationService;
+    private final TextService textService;
+    private final S3Service s3Service;
 
     public Mono<ChannelResponseDto> createChannel(Long spaceId, ChannelRequestDto requestDto) {
         return spaceService.findSpaceById(spaceId)
@@ -39,7 +44,18 @@ public class ChannelFacade {
     }
 
     public Mono<Void> deleteChannel(Long channelId) {
-        return channelService.deleteChannel(channelId);
+        return textService.findTextsByChannelId(channelId)
+                .flatMap(text -> {
+                    if (text.getType().equals(Text.TextType.TEXT)) {
+                        return textService.deleteText(text.getId());
+                    } else if (text.getType().equals(Text.TextType.FILE)) {
+                        return s3Service.deleteObject(text.getContents())
+                                .then(textService.deleteText(text.getId()));
+                    } else {
+                        return Mono.empty();
+                    }
+                })
+                .then(channelService.deleteChannel(channelId));
     }
 
     public Flux<SpaceMemberDto> getSpaceMembersByChannelId(Long channelId) {

--- a/src/main/java/com/echo/echo/domain/text/TextService.java
+++ b/src/main/java/com/echo/echo/domain/text/TextService.java
@@ -58,6 +58,10 @@ public class TextService {
                 .flatMap(repository::delete);
     }
 
+    public Mono<Void> deleteText(String textId) {
+        return repository.deleteById(textId);
+    }
+
     public Sinks.Many<TextResponse> getSink(Long channelId) {
         return channelSinks.compute(channelId, (id, existingSink) -> {
             if (existingSink == null || existingSink.currentSubscriberCount() == 0) {
@@ -79,6 +83,10 @@ public class TextService {
 
     public void startSession(Long userId, Long channelId) {
         log.debug("채팅방 입장, 유저 id {}, channelId {} notification 데이터를 삭제합니다.", userId, channelId);
+    }
+
+    public Flux<Text> findTextsByChannelId(Long channelId) {
+        return repository.findAllByChannelId(channelId);
     }
 
 }

--- a/src/main/java/com/echo/echo/domain/text/controller/TextController.java
+++ b/src/main/java/com/echo/echo/domain/text/controller/TextController.java
@@ -1,7 +1,6 @@
 package com.echo.echo.domain.text.controller;
 
 import com.echo.echo.domain.text.TextFacade;
-import com.echo.echo.domain.text.TextService;
 import com.echo.echo.domain.text.dto.TextRequest;
 import com.echo.echo.security.principal.UserPrincipal;
 import lombok.RequiredArgsConstructor;
@@ -16,7 +15,6 @@ import reactor.core.publisher.Mono;
 public class TextController {
 
     private final TextFacade textFacade;
-    private final TextService textService;
 
     @PostMapping("/{channelId}/file")
     public Mono<Void> textChatFileUpload(@PathVariable("channelId") Long channelId,

--- a/src/main/java/com/echo/echo/domain/text/controller/TextWebSocketHandler.java
+++ b/src/main/java/com/echo/echo/domain/text/controller/TextWebSocketHandler.java
@@ -3,8 +3,8 @@ package com.echo.echo.domain.text.controller;
 import com.echo.echo.common.redis.RedisConst;
 import com.echo.echo.common.redis.RedisPublisher;
 import com.echo.echo.common.util.ObjectStringConverter;
-import com.echo.echo.domain.dm.DmService;
 import com.echo.echo.domain.channel.ChannelService;
+import com.echo.echo.domain.dm.DmService;
 import com.echo.echo.domain.text.TextService;
 import com.echo.echo.domain.text.dto.TextRequest;
 import com.echo.echo.domain.text.dto.TextResponse;
@@ -12,16 +12,13 @@ import com.echo.echo.domain.text.dto.TypingRequest;
 import com.echo.echo.domain.text.dto.TypingResponse;
 import com.echo.echo.domain.text.entity.Text;
 import com.echo.echo.security.jwt.JwtProvider;
-
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-
 import org.springframework.data.redis.listener.ChannelTopic;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.socket.WebSocketHandler;
 import org.springframework.web.reactive.socket.WebSocketMessage;
 import org.springframework.web.reactive.socket.WebSocketSession;
-
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.core.publisher.Sinks;

--- a/src/main/java/com/echo/echo/domain/text/dto/TypingResponse.java
+++ b/src/main/java/com/echo/echo/domain/text/dto/TypingResponse.java
@@ -2,7 +2,6 @@ package com.echo.echo.domain.text.dto;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-
 import lombok.Getter;
 
 @Getter

--- a/src/main/java/com/echo/echo/domain/text/entity/Text.java
+++ b/src/main/java/com/echo/echo/domain/text/entity/Text.java
@@ -44,8 +44,7 @@ public class Text extends TimeStamp {
     }
 
     public enum TextType {
-        TEXT,
-        FILE,
+        TEXT, FILE
     }
 
 }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
`refactor/text` -> `dev`

### 변경 사항
- 텍스트 채널 삭제 시 해당 채널에서 생성된 Text Entity 및 S3 파일 삭제
- S3 파일 업로드 간 파일의 최대 허용량 증가
- Text 도메인 내부 미사용 Import 제거
- Text 도메인 내 미사용 Bean 주입 제거
- ObjectStringConverter 클래스 Annotation 설정 변경
- Text 도메인 부가기능으로 인한 DM 기능 비활성화 해결
- 채널에 입장인원이 한계인 상태에서 추가적인 입장을 했을 때 doFinally에 의해 DB의 현재 입장인원을 감소시키는 문제 해결

### 테스트 결과
> ### 1. 채널 삭제 시 Text Entity의 TextType이 FILE인 경우 내부 contents 필드를 참고하여 S3에 저장된 파일 삭제 연계 확인
> ### 2. ObjectStringConverter 클래스 Annotation 설정 변경 후 정상 작동 확인